### PR TITLE
Restructure command-line args

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -718,9 +718,9 @@ checksum = "343f3f510c2915908f155e94f17220b19ccfacf2a64a2a5d8004f2c3e311e7fd"
 
 [[package]]
 name = "syn"
-version = "1.0.51"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b4f34193997d92804d359ed09953e25d5138df6bcc055a71bf68ee89fdf9223"
+checksum = "6c1e438504729046a5cfae47f97c30d6d083c7d91d94603efdae3477fc070d4c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,14 +9,16 @@ use hsh::{
 
 #[derive(Debug, StructOpt)]
 struct Opt {
+    /// The string to be hashed
     #[structopt()]
     string: String,
-    #[structopt(short, long)]
+    /// The hash function to use
+    #[structopt(possible_values = &HashFunction::variants(), case_insensitive=true)]
     function: HashFunction,
-    #[structopt(short, long)]
-    bytes: bool,
+    /// The cost to use when hashing with the Bcrypt hash function
     #[structopt(short, long, required_if("function", "bcrypt"))]
     cost: Option<u32>,
+    /// The 16-byte salt to use when hashing with the Bcrypt hash function
     #[structopt(short, long, required_if("function", "bcrypt"))]
     salt: Option<Salt>,
 }
@@ -24,9 +26,5 @@ struct Opt {
 fn main() {
     let opt = Opt::from_args();
     let hash = hash(&opt.string, opt.function, opt.cost, opt.salt);
-    if opt.bytes {
-        println!("{:?}", hash.as_bytes());
-    } else {
-        println!("{}", hash.as_hex());
-    }
+    println!("{}", hash.as_hex());
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -47,6 +47,48 @@ pub enum HashFunction {
     Whirlpool,
 }
 
+impl HashFunction {
+    pub fn variants() -> Vec<&'static str> {
+        vec![
+            "bcrypt",
+            "blake2",
+            "gost94test",
+            "gost94crypto",
+            "groestl224",
+            "groestl256",
+            "groestl384",
+            "groestl512",
+            "keccak224",
+            "keccak256",
+            "keccak256full",
+            "keccak384",
+            "keccak512",
+            "md2",
+            "md4",
+            "md5",
+            "ripemd160",
+            "ripemd320",
+            "sha1",
+            "sha224",
+            "sha256",
+            "sha384",
+            "sha512",
+            "sha3-224",
+            "sha3-256",
+            "sha3-384",
+            "sha3-512",
+            "shabal192",
+            "shabal224",
+            "shabal256",
+            "shabal384",
+            "shabal512",
+            "streebog256",
+            "streebog512",
+            "whirlpool",
+        ]
+    }
+}
+
 impl FromStr for HashFunction {
     type Err = HshErr;
 
@@ -77,10 +119,10 @@ impl FromStr for HashFunction {
             "sha256" => Ok(Sha256),
             "sha384" => Ok(Sha384),
             "sha512" => Ok(Sha512),
-            "sha3_224" => Ok(Sha3_224),
-            "sha3_256" => Ok(Sha3_256),
-            "sha3_384" => Ok(Sha3_384),
-            "sha3_512" => Ok(Sha3_512),
+            "sha3-224" => Ok(Sha3_224),
+            "sha3-256" => Ok(Sha3_256),
+            "sha3-384" => Ok(Sha3_384),
+            "sha3-512" => Ok(Sha3_512),
             "shabal192" => Ok(Shabal192),
             "shabal224" => Ok(Shabal224),
             "shabal256" => Ok(Shabal256),
@@ -94,6 +136,7 @@ impl FromStr for HashFunction {
     }
 }
 
+#[derive(Debug)]
 pub struct HashOutput {
     bytes: Vec<u8>,
 }
@@ -143,6 +186,51 @@ mod test {
     fn test_hash_function_from_str_invalid() {
         let err = HashFunction::from_str("foobar").unwrap_err();
         assert_eq!(HshErr::InvalidHashFunction(String::from("foobar")), err);
+    }
+
+    #[test]
+    fn test_hash_function_variants() {
+        let variants = HashFunction::variants();
+        assert_eq!(
+            vec![
+                "bcrypt",
+                "blake2",
+                "gost94test",
+                "gost94crypto",
+                "groestl224",
+                "groestl256",
+                "groestl384",
+                "groestl512",
+                "keccak224",
+                "keccak256",
+                "keccak256full",
+                "keccak384",
+                "keccak512",
+                "md2",
+                "md4",
+                "md5",
+                "ripemd160",
+                "ripemd320",
+                "sha1",
+                "sha224",
+                "sha256",
+                "sha384",
+                "sha512",
+                "sha3-224",
+                "sha3-256",
+                "sha3-384",
+                "sha3-512",
+                "shabal192",
+                "shabal224",
+                "shabal256",
+                "shabal384",
+                "shabal512",
+                "streebog256",
+                "streebog512",
+                "whirlpool",
+            ],
+            variants,
+        )
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -40,7 +40,7 @@ fn missing_args() -> Result<(), Box<dyn Error>> {
         vec![
             "The following required arguments were not provided:",
             "<string>",
-            "--function <function>",
+            "<function>",
         ],
     );
 
@@ -49,16 +49,16 @@ fn missing_args() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn invalid_hash_function() -> Result<(), Box<dyn Error>> {
-    let cmd = setup(vec!["Hello, world!", "-f", "foo"])?;
+    let cmd = setup(vec!["Hello, world!", "foo"])?;
 
-    assert_errors(cmd, vec!["invalid hash function `foo`"]);
+    assert_errors(cmd, vec!["'foo' isn't a valid value for '<function>'"]);
 
     Ok(())
 }
 
 #[test]
 fn sha1_hex_test() -> Result<(), Box<dyn Error>> {
-    let cmd = setup(vec!["Hello, world!", "-f", "sha1"])?;
+    let cmd = setup(vec!["Hello, world!", "sha1"])?;
 
     assert_success(cmd, vec!["943a702d06f34599aee1f8da8ef9f7296031d699"]);
 
@@ -66,17 +66,8 @@ fn sha1_hex_test() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn sha1_bytes_test() -> Result<(), Box<dyn Error>> {
-    let cmd = setup(vec!["Hello, world!", "-bf", "sha1"])?;
-
-    assert_success(cmd, vec!["[148, 58, 112, 45, 6, 243, 69, 153, 174, 225, 248, 218, 142, 249, 247, 41, 96, 49, 214, 153]"]);
-
-    Ok(())
-}
-
-#[test]
 fn missing_bcrypt_inputs() -> Result<(), Box<dyn Error>> {
-    let cmd = setup(vec!["Hello, world!", "-f", "bcrypt"])?;
+    let cmd = setup(vec!["Hello, world!", "bcrypt"])?;
 
     assert_errors(
         cmd,
@@ -91,7 +82,7 @@ fn missing_bcrypt_inputs() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn missing_bcrypt_salt() -> Result<(), Box<dyn Error>> {
-    let cmd = setup(vec!["Hello, world!", "-f", "bcrypt", "-c", "1"])?;
+    let cmd = setup(vec!["Hello, world!", "bcrypt", "-c", "1"])?;
 
     assert_errors(
         cmd,
@@ -108,7 +99,6 @@ fn missing_bcrypt_salt() -> Result<(), Box<dyn Error>> {
 fn bcrypt_invalid_salt_hex_odd_digits() -> Result<(), Box<dyn Error>> {
     let cmd = setup(vec![
         "Hello, world!",
-        "-f",
         "bcrypt",
         "-c",
         "1",
@@ -125,7 +115,6 @@ fn bcrypt_invalid_salt_hex_odd_digits() -> Result<(), Box<dyn Error>> {
 fn bcrypt_invalid_salt_incorrect_length_short() -> Result<(), Box<dyn Error>> {
     let cmd = setup(vec![
         "Hello, world!",
-        "-f",
         "bcrypt",
         "-c",
         "1",
@@ -145,7 +134,6 @@ fn bcrypt_invalid_salt_incorrect_length_short() -> Result<(), Box<dyn Error>> {
 fn bcrypt_invalid_salt_incorrect_length_long() -> Result<(), Box<dyn Error>> {
     let cmd = setup(vec![
         "Hello, world!",
-        "-f",
         "bcrypt",
         "-c",
         "1",
@@ -165,7 +153,6 @@ fn bcrypt_invalid_salt_incorrect_length_long() -> Result<(), Box<dyn Error>> {
 fn bcrypt_hex_test() -> Result<(), Box<dyn Error>> {
     let cmd = setup(vec![
         "Hello, world!",
-        "-f",
         "bcrypt",
         "-c",
         "1",

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -97,14 +97,7 @@ fn missing_bcrypt_salt() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn bcrypt_invalid_salt_hex_odd_digits() -> Result<(), Box<dyn Error>> {
-    let cmd = setup(vec![
-        "Hello, world!",
-        "bcrypt",
-        "-c",
-        "1",
-        "-s",
-        "1a54e",
-    ])?;
+    let cmd = setup(vec!["Hello, world!", "bcrypt", "-c", "1", "-s", "1a54e"])?;
 
     assert_errors(cmd, vec!["invalid salt hex -- Odd number of digits"]);
 


### PR DESCRIPTION
* Make the `function` argument a positional argument rather than an 
option
* Add help text to args
* Add `possible_values` to `function` argument