### PR TITLE
Add arguments to control format of inputs and outputs, improve error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,6 +49,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
+name = "b64"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7afdd34e1f84d4a66e30add7c0d8c784c2b8b2240dbc7feaccee75682a369f26"
+
+[[package]]
 name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,6 +210,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "exitcode"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de853764b47027c2e862a995c34978ffa63c1501f2e15f987ba11bd4f9bba193"
+
+[[package]]
 name = "float-cmp"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,16 +313,20 @@ name = "hsh"
 version = "0.1.0"
 dependencies = [
  "assert_cmd",
+ "b64",
  "bcrypt",
  "blake2",
+ "exitcode",
  "gost94",
  "groestl",
  "hex",
+ "lazy_static",
  "md-5",
  "md2",
  "md4",
  "predicates",
  "proptest",
+ "regex",
  "ripemd160",
  "ripemd320",
  "sha-1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,10 @@ shabal = "0.3.0"
 streebog = "0.9.2"
 structopt = "0.3.20"
 whirlpool = "0.9.0"
+b64 = "0.4.0"
+lazy_static = "1.4.0"
+regex = "1.4.2"
+exitcode = "1.1.2"
 
 [dev-dependencies]
 assert_cmd = "1.0.1"

--- a/proptest-regressions/bcrypt/mod.txt
+++ b/proptest-regressions/bcrypt/mod.txt
@@ -5,3 +5,4 @@
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
 cc 5b7a5cb0bc9dab4c7e78ca879e72e7c4ec3f40c248584545310e7fb8b79bfe94 # shrinks to s = ""
+cc 01fe11aaf898432dc357be3b6e358b94bc876ef40de4390352001a8b3ff73202 # shrinks to str = " a A 0A a \u{0}\u{0}\u{b}\u{0} ࠀ"

--- a/src/bcrypt/mod.rs
+++ b/src/bcrypt/mod.rs
@@ -40,13 +40,13 @@ impl Salt {
     pub fn from_bytes(str: &str) -> HshResult<Self> {
         let len = str.len();
 
-        if !(str.chars().nth(0) == Some('[') && str.chars().last() == Some(']')) {
+        if !(str.starts_with('[') && str.ends_with(']')) {
             return Err(HshErr::SaltFromStrError(String::from(
                 "invalid format for salt byte input",
             )));
         }
 
-        let strs: Vec<&str> = str[1..len - 1].split(",").collect();
+        let strs: Vec<&str> = str[1..len - 1].split(',').collect();
         let mut bytes = Vec::with_capacity(str.len());
 
         for s in strs {
@@ -117,7 +117,7 @@ impl FromStr for Salt {
     type Err = HshErr;
 
     fn from_str(str: &str) -> HshResult<Salt> {
-        if str.len() == 0 {
+        if str.is_empty() {
             return Err(HshErr::SaltFromStrError(String::from(
                 "salt cannot be blank",
             )));
@@ -149,7 +149,7 @@ impl Hasher for BcryptHasher {
     type HashInput = BcryptInput;
 
     fn hash(&self, input: BcryptInput, bytes: &[u8]) -> HshResult<HashOutput> {
-        if bytes.len() == 0 || bytes.len() > 72 {
+        if bytes.is_empty() || bytes.len() > 72 {
             return Err(HshErr::UnsuportedStrLength(String::from(
                 "input string for bcrypt hash function must be between 0 and 72 bytes",
             )));

--- a/src/bcrypt/mod.rs
+++ b/src/bcrypt/mod.rs
@@ -1,10 +1,16 @@
 // Std imports
 use std::str::FromStr;
 
+// External imports
+use b64::FromBase64;
+use lazy_static::lazy_static;
+use regex::Regex;
+
 // Internal imports
+use crate::format::get_salt_format;
 use crate::error::{HshErr, HshResult};
 use crate::hasher::Hasher;
-use crate::types::HashOutput;
+use crate::types::{Format, HashOutput};
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Salt([u8; 16]);
@@ -16,8 +22,8 @@ impl Salt {
 
     pub fn from_vec(data: Vec<u8>) -> HshResult<Self> {
         if data.len() != 16 {
-            return Err(HshErr::InvalidSalt(format!(
-                "incorrect salt length (should be 16 bytes, found {})",
+            return Err(HshErr::IncorrectSaltLength(format!(
+                "should be 16 bytes, found {}",
                 data.len()
             )));
         }
@@ -30,19 +36,81 @@ impl Salt {
 
         Ok(Self::new(arr))
     }
+
+    pub fn from_bytes(str: &str) -> HshResult<Self> {
+        let len = str.len();
+
+        if !(str.chars().nth(0) == Some('[') && str.chars().last() == Some(']')) {
+            return Err(HshErr::SaltFromStrError(String::from("invalid format for salt byte input")));
+        }
+
+        let strs: Vec<&str> = str[1..len - 1].split(",").collect();
+        let mut bytes = Vec::with_capacity(str.len());
+
+        for s in strs {
+            let s = s.trim();
+            let res = u8::from_str(s);
+
+            if res.is_err() {
+                return Err(HshErr::SaltFromStrError(format!("invalid string '{}' in byte input", s)));
+            }
+
+            bytes.push(res.unwrap());
+        }
+
+        Self::from_vec(bytes)
+    }
+
+    pub fn from_hex(str: &str) -> HshResult<Self> {
+        lazy_static! {
+            static ref REGEX: Regex = Regex::new(r"([^0-9a-fA-F])").unwrap();
+        }
+
+        if str.len() % 2 != 0 {
+            return Err(HshErr::SaltFromStrError(String::from("hex must be of even digits")));
+        }
+
+        let illegal_char = REGEX.find(str);
+        if illegal_char.is_some() {
+            return Err(HshErr::SaltFromStrError(format!("hex contains illegal character '{}'", illegal_char.unwrap().as_str())));
+        }
+
+        let decoded = hex::decode(str).unwrap();
+        Self::from_vec(decoded)
+    }
+
+    pub fn from_base64(str: &str) -> HshResult<Self> {
+        lazy_static! {
+            static ref REGEX: Regex = Regex::new(r"([^0-9a-zA-Z/\+=])").unwrap();
+        }
+
+        if str.len() % 4 != 0 {
+            return Err(HshErr::SaltFromStrError(String::from("length of base64 string must be a multiple of four")));
+        }
+
+        let illegal_char = REGEX.find(str);
+        if illegal_char.is_some() {
+            return Err(HshErr::SaltFromStrError(format!("base64 string contains illegal character '{}'", illegal_char.unwrap().as_str())));
+        }
+
+        let decoded = str.from_base64().unwrap();
+        Salt::from_vec(decoded)
+    }
 }
 
 impl FromStr for Salt {
     type Err = HshErr;
 
     fn from_str(str: &str) -> HshResult<Salt> {
-        let decoded = hex::decode(str);
-
-        if let Err(err) = decoded {
-            return Err(HshErr::InvalidSaltHex(err));
+        if str.len() == 0 {
+            return Err(HshErr::SaltFromStrError(String::from("salt cannot be blank")));
         }
 
-        Salt::from_vec(decoded.unwrap())
+        match get_salt_format() {
+            Format::Base64 => Salt::from_base64(str),
+            Format::Bytes => Salt::from_bytes(str),
+            Format::Hex => Salt::from_hex(str),
+        }
     }
 }
 
@@ -63,17 +131,25 @@ pub struct BcryptHasher;
 impl Hasher for BcryptHasher {
     type HashInput = BcryptInput;
 
-    fn hash(&self, input: BcryptInput, bytes: &[u8]) -> HashOutput {
+    fn hash(&self, input: BcryptInput, bytes: &[u8]) -> HshResult<HashOutput> {
+        if bytes.len() == 0 || bytes.len() > 72 {
+            return Err(HshErr::UnsuportedStrLength(String::from("input string for bcrypt hash function must be between 0 and 72 bytes")));
+        }
+
         let mut hash: [u8; 24] = [0; 24];
         bcrypt::bcrypt(input.cost, &input.salt.0, bytes, &mut hash);
-        HashOutput::new(hash.to_vec())
+
+        Ok(HashOutput::new(hash.to_vec()))
     }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::format::FORMAT_MODE;
+    use crate::types::Format;
     use proptest::prelude::*;
+    use b64::{CharacterSet, Config, Newline, ToBase64};
 
     #[test]
     fn test_salt_new() {
@@ -100,8 +176,8 @@ mod test {
         let err = Salt::from_vec(bytes).unwrap_err();
 
         assert_eq!(
-            HshErr::InvalidSalt(String::from(
-                "incorrect salt length (should be 16 bytes, found 0)"
+            HshErr::IncorrectSaltLength(String::from(
+                "should be 16 bytes, found 0"
             )),
             err,
         )
@@ -116,74 +192,388 @@ mod test {
         let err = Salt::from_vec(bytes).unwrap_err();
 
         assert_eq!(
-            HshErr::InvalidSalt(String::from(
-                "incorrect salt length (should be 16 bytes, found 22)"
+            HshErr::IncorrectSaltLength(String::from(
+                "should be 16 bytes, found 22"
             )),
             err,
         );
     }
 
     #[test]
-    fn test_salt_from_str_valid() {
-        let bytes = [7, 4, 2, 5, 7, 2, 6, 19, 1, 0, 3, 3, 6, 4, 2, 33];
-        let hex = hex::encode(bytes);
+    fn test_salt_from_bytes_valid() {
+        let bytes = "[7, 4, 2, 5, 7, 2, 6, 19, 1, 0, 3, 3, 6, 4, 2, 33]";
 
-        let salt = Salt::from_str(&hex).unwrap();
+        let salt = Salt::from_bytes(&bytes).unwrap();
 
-        assert_eq!(bytes, salt.0);
+        assert_eq!([7, 4, 2, 5, 7, 2, 6, 19, 1, 0, 3, 3, 6, 4, 2, 33], salt.0);
     }
 
     #[test]
-    fn test_salt_from_empty_str() {
-        let hex = "";
+    fn test_salt_from_empty_bytes() {
+        let bytes = "";
 
-        let err = Salt::from_str(&hex).unwrap_err();
+        let err = Salt::from_bytes(&bytes).unwrap_err();
 
         assert_eq!(
-            HshErr::InvalidSalt(String::from(
-                "incorrect salt length (should be 16 bytes, found 0)"
+            HshErr::SaltFromStrError(String::from(
+                "invalid format for salt byte input"
             )),
             err,
         )
     }
 
     #[test]
-    fn test_salt_from_str_odd_length() {
-        let hex = "a83e8f932";
+    fn test_salt_from_bytes_invalid_bytes() {
+        let bytes = "[7, 4, 2, 5, 7, 2, 6, nineteen, 1, 0, 3, 3, 6, 4, 2, 33]";
 
-        let err = Salt::from_str(&hex).unwrap_err();
+        let err = Salt::from_bytes(&bytes).unwrap_err();
 
-        assert_eq!(HshErr::InvalidSaltHex(hex::FromHexError::OddLength), err);
+        assert_eq!(HshErr::SaltFromStrError(String::from("invalid string 'nineteen' in byte input")), err);
     }
 
     #[test]
-    fn test_salt_from_str_invalid_characters() {
-        let hex = "an7c123'573b9VB769p/yvgwoehgi42\"";
+    fn test_salt_from_bytes_long() {
+        let bytes = "[8, 42, 4, 0, 72, 83, 5, 4, 185, 4, 68, 42, 9, 0, 2, 84, 4, 82, 5, 216, 0, 137]";
 
-        let err = Salt::from_str(&hex).unwrap_err();
-        let err_msg = format!("{}", err);
+        let err = Salt::from_bytes(&bytes).unwrap_err();
 
         assert_eq!(
-            "invalid salt hex -- Invalid character 'n' at position 1",
-            err_msg
+            HshErr::IncorrectSaltLength(String::from(
+                "should be 16 bytes, found 22"
+            )),
+            err,
         );
     }
 
     #[test]
-    fn test_salt_from_str_long() {
+    fn test_salt_from_hex_valid() {
+        let bytes = [7, 4, 2, 5, 7, 2, 6, 19, 1, 0, 3, 3, 6, 4, 2, 33];
+        let hex = hex::encode(bytes);
+
+        let salt = Salt::from_hex(&hex).unwrap();
+
+        assert_eq!(bytes, salt.0);
+    }
+
+    #[test]
+    fn test_salt_from_empty_hex() {
+        let hex = "";
+
+        let err = Salt::from_hex(&hex).unwrap_err();
+
+        assert_eq!(
+            HshErr::IncorrectSaltLength(String::from(
+                "should be 16 bytes, found 0"
+            )),
+            err,
+        )
+    }
+
+    #[test]
+    fn test_salt_from_hex_odd_length() {
+        let hex = "a83e8f932";
+
+        let err = Salt::from_hex(&hex).unwrap_err();
+
+        assert_eq!(HshErr::SaltFromStrError(String::from("hex must be of even digits")), err);
+    }
+
+    #[test]
+    fn test_salt_from_hex_invalid_characters() {
+        let hex = "an7c123'573b9VB769p/yvgwoehgi42\"";
+
+        let err = Salt::from_hex(&hex).unwrap_err();
+
+        assert_eq!(HshErr::SaltFromStrError(String::from("hex contains illegal character 'n'")), err);
+    }
+
+    #[test]
+    fn test_salt_from_hex_long() {
         let bytes = [
             8, 42, 4, 0, 72, 83, 5, 4, 185, 4, 68, 42, 9, 0, 2, 84, 4, 82, 5, 216, 0, 137,
         ];
         let hex = hex::encode(bytes);
 
-        let err = Salt::from_str(&hex).unwrap_err();
+        let err = Salt::from_hex(&hex).unwrap_err();
 
         assert_eq!(
-            HshErr::InvalidSalt(String::from(
-                "incorrect salt length (should be 16 bytes, found 22)"
+            HshErr::IncorrectSaltLength(String::from(
+                "should be 16 bytes, found 22"
             )),
-            err
+            err,
         );
+    }
+
+    #[test]
+    fn test_salt_from_base64_valid() {
+        let bytes = [7, 4, 2, 5, 7, 2, 6, 19, 1, 0, 3, 3, 6, 4, 2, 33];
+        let base64 = bytes.to_base64(Config {
+            char_set: CharacterSet::Standard,
+            newline: Newline::LF,
+            pad: true,
+            line_length: None,
+        });
+
+        let salt = Salt::from_base64(&base64).unwrap();
+
+        assert_eq!(bytes, salt.0);
+    }
+
+    #[test]
+    fn test_salt_from_empty_base64() {
+        let base64 = "";
+
+        let err = Salt::from_base64(&base64).unwrap_err();
+
+        assert_eq!(
+            HshErr::IncorrectSaltLength(String::from(
+                "should be 16 bytes, found 0"
+            )),
+            err,
+        )
+    }
+
+    #[test]
+    fn test_salt_from_base64_invalid_length() {
+        let base64 = "a83eMf932";
+
+        let err = Salt::from_base64(&base64).unwrap_err();
+
+        assert_eq!(HshErr::SaltFromStrError(String::from("length of base64 string must be a multiple of four")), err);
+    }
+
+    #[test]
+    fn test_salt_from_base64_invalid_characters() {
+        let base64 = "an7c123$573M9VB769p/yv+wo~ehgi42";
+
+        let err = Salt::from_base64(&base64).unwrap_err();
+
+        assert_eq!(HshErr::SaltFromStrError(String::from("base64 string contains illegal character '$'")), err);
+    }
+
+    #[test]
+    fn test_salt_from_base64_long() {
+        let bytes = [
+            8, 42, 4, 0, 72, 83, 5, 4, 185, 4, 68, 42, 9, 0, 2, 84, 4, 82, 5, 216, 0, 137,
+        ];
+        let base64 = bytes.to_base64(Config {
+            char_set: CharacterSet::Standard,
+            newline: Newline::LF,
+            pad: true,
+            line_length: None,
+        });
+
+        let err = Salt::from_base64(&base64).unwrap_err();
+
+        assert_eq!(
+            HshErr::IncorrectSaltLength(String::from(
+                "should be 16 bytes, found 22"
+            )),
+            err,
+        );
+    }
+
+    #[test]
+    fn test_salt_from_str_valid_bytes() {
+        FORMAT_MODE.test_with_salt_format(Format::Bytes, || {
+            let bytes = "[7, 4, 2, 5, 7, 2, 6, 19, 1, 0, 3, 3, 6, 4, 2, 33]";
+
+            let salt = Salt::from_str(&bytes).unwrap();
+
+            assert_eq!([7, 4, 2, 5, 7, 2, 6, 19, 1, 0, 3, 3, 6, 4, 2, 33], salt.0);
+        });
+    }
+
+    #[test]
+    fn test_salt_from_str_empty_bytes() {
+        FORMAT_MODE.test_with_salt_format(Format::Bytes, || {
+            let bytes = "";
+
+            let err = Salt::from_str(&bytes).unwrap_err();
+
+            assert_eq!(
+                HshErr::SaltFromStrError(String::from(
+                    "salt cannot be blank"
+                )),
+                err,
+            )
+        });
+    }
+
+    #[test]
+    fn test_salt_from_str_invalid_bytes() {
+        FORMAT_MODE.test_with_salt_format(Format::Bytes, || {
+            let bytes = "[7, 4, 2, 5, 7, 2, 6, nineteen, 1, 0, 3, 3, 6, 4, 2, 33]";
+
+            let err = Salt::from_str(&bytes).unwrap_err();
+
+            assert_eq!(HshErr::SaltFromStrError(String::from("invalid string 'nineteen' in byte input")), err);
+        });
+    }
+
+    #[test]
+    fn test_salt_from_str_long_bytes() {
+        FORMAT_MODE.test_with_salt_format(Format::Bytes, || {
+            let bytes = "[8, 42, 4, 0, 72, 83, 5, 4, 185, 4, 68, 42, 9, 0, 2, 84, 4, 82, 5, 216, 0, 137]";
+
+            let err = Salt::from_str(&bytes).unwrap_err();
+
+            assert_eq!(
+                HshErr::IncorrectSaltLength(String::from(
+                    "should be 16 bytes, found 22"
+                )),
+                err,
+            );
+        })
+    }
+
+    #[test]
+    fn test_salt_from_str_valid_hex() {
+        FORMAT_MODE.test_with_salt_format(Format::Hex, || {
+            let bytes = [7, 4, 2, 5, 7, 2, 6, 19, 1, 0, 3, 3, 6, 4, 2, 33];
+            let hex = hex::encode(bytes);
+
+            let salt = Salt::from_str(&hex).unwrap();
+
+            assert_eq!(bytes, salt.0);
+        });
+    }
+
+    #[test]
+    fn test_salt_from_str_empty_hex() {
+        FORMAT_MODE.test_with_salt_format(Format::Hex, || {
+            let hex = "";
+
+            let err = Salt::from_str(&hex).unwrap_err();
+
+            assert_eq!(
+                HshErr::SaltFromStrError(String::from(
+                    "salt cannot be blank"
+                )),
+                err,
+            )
+        });
+    }
+
+    #[test]
+    fn test_salt_from_str_odd_length_hex() {
+        FORMAT_MODE.test_with_salt_format(Format::Hex, || {
+            let hex = "a83e8f932";
+
+            let err = Salt::from_str(&hex).unwrap_err();
+
+            assert_eq!(HshErr::SaltFromStrError(String::from("hex must be of even digits")), err);
+        });
+    }
+
+    #[test]
+    fn test_salt_from_str_invalid_hex_characters() {
+        FORMAT_MODE.test_with_salt_format(Format::Hex, || {
+            let hex = "an7c123'573b9VB769p/yvgwoehgi42\"";
+
+            let err = Salt::from_str(&hex).unwrap_err();
+
+            assert_eq!(HshErr::SaltFromStrError(String::from("hex contains illegal character 'n'")), err);
+        });
+    }
+
+    #[test]
+    fn test_salt_from_str_long_hex() {
+        FORMAT_MODE.test_with_salt_format(Format::Hex, || {
+            let bytes = [
+                8, 42, 4, 0, 72, 83, 5, 4, 185, 4, 68, 42, 9, 0, 2, 84, 4, 82, 5, 216, 0, 137,
+            ];
+            let hex = hex::encode(bytes);
+
+            let err = Salt::from_str(&hex).unwrap_err();
+
+            assert_eq!(
+                HshErr::IncorrectSaltLength(String::from(
+                    "should be 16 bytes, found 22"
+                )),
+                err,
+            );
+        });
+    }
+
+    #[test]
+    fn test_salt_from_str_valid_base64() {
+        FORMAT_MODE.test_with_salt_format(Format::Base64, || {
+            let bytes = [7, 4, 2, 5, 7, 2, 6, 19, 1, 0, 3, 3, 6, 4, 2, 33];
+            let base64 = bytes.to_base64(Config {
+                char_set: CharacterSet::Standard,
+                newline: Newline::LF,
+                pad: true,
+                line_length: None,
+            });
+
+            let salt = Salt::from_str(&base64).unwrap();
+
+            assert_eq!(bytes, salt.0);
+        });
+    }
+
+    #[test]
+    fn test_salt_from_str_empty_base64() {
+        FORMAT_MODE.test_with_salt_format(Format::Base64, || {
+            let base64 = "";
+
+            let err = Salt::from_str(&base64).unwrap_err();
+
+            assert_eq!(
+                HshErr::SaltFromStrError(String::from(
+                    "salt cannot be blank"
+                )),
+                err,
+            );
+        });
+    }
+
+    #[test]
+    fn test_salt_from_str_invalid_length_base64() {
+        FORMAT_MODE.test_with_salt_format(Format::Base64, || {
+            let base64 = "a83eMf932";
+
+            let err = Salt::from_str(&base64).unwrap_err();
+
+            assert_eq!(HshErr::SaltFromStrError(String::from("length of base64 string must be a multiple of four")), err);
+        });
+    }
+
+    #[test]
+    fn test_salt_from_str_invalid_base64_characters() {
+        FORMAT_MODE.test_with_salt_format(Format::Base64, || {
+            let base64 = "=an7c123;573M9VB769p/yv+wo~ehgi42\"`G";
+
+            println!("{}", base64);
+            let err = Salt::from_str(&base64).unwrap_err();
+
+            assert_eq!(HshErr::SaltFromStrError(String::from("base64 string contains illegal character ';'")), err);
+        });
+    }
+
+    #[test]
+    fn test_salt_from_str_long_base64() {
+        FORMAT_MODE.test_with_salt_format(Format::Base64, || {
+            let bytes = [
+                8, 42, 4, 0, 72, 83, 5, 4, 185, 4, 68, 42, 9, 0, 2, 84, 4, 82, 5, 216, 0, 137,
+            ];
+            let base64 = bytes.to_base64(Config {
+                char_set: CharacterSet::Standard,
+                newline: Newline::LF,
+                pad: true,
+                line_length: None,
+            });
+
+            let err = Salt::from_str(&base64).unwrap_err();
+
+            assert_eq!(
+                HshErr::IncorrectSaltLength(String::from(
+                    "should be 16 bytes, found 22"
+                )),
+                err,
+            );
+        });
     }
 
     #[test]
@@ -200,12 +590,12 @@ mod test {
     #[test]
     fn test_bcrypt_hash_password() {
         let cost = 10;
-        let salt = Salt::from_str("07040205070206130100030306040221").unwrap();
+        let salt = Salt::from_hex("07040205070206130100030306040221").unwrap();
         let input = BcryptInput::new(cost, salt);
 
         let password = "password";
 
-        let hash = BcryptHasher.hash_str(input, password);
+        let hash = BcryptHasher.hash_str(input, password).unwrap();
 
         assert_eq!(
             "dfcd71d5fb5c9f17bddc20eff324be2926529c01c440fcfb",
@@ -214,18 +604,74 @@ mod test {
     }
 
     #[test]
+    fn test_bcrypt_hash_empty_string() {
+        let cost = 10;
+        let salt = Salt::from_hex("07040205070206130100030306040221").unwrap();
+        let input = BcryptInput::new(cost, salt);
+
+        let err = BcryptHasher.hash_str(input, "").unwrap_err();
+
+        assert_eq!(
+            HshErr::UnsuportedStrLength(
+                String::from(
+                    "input string for bcrypt hash function must be between 0 and 72 bytes"
+                )
+            ),
+            err
+        );
+    }
+
+    #[test]
     fn test_bcrypt_hash_bytes() {
         let cost = 10;
-        let salt = Salt::from_str("07040205070206130100030306040221").unwrap();
+        let salt = Salt::from_hex("07040205070206130100030306040221").unwrap();
         let input = BcryptInput::new(cost, salt);
 
         let bytes = b"password";
 
-        let hash = BcryptHasher.hash(input, bytes);
+        let hash = BcryptHasher.hash(input, bytes).unwrap();
 
         assert_eq!(
             "dfcd71d5fb5c9f17bddc20eff324be2926529c01c440fcfb",
             hash.as_hex()
+        );
+    }
+
+    #[test]
+    fn test_bcrypt_hash_empty_bytes() {
+        let cost = 10;
+        let salt = Salt::from_hex("07040205070206130100030306040221").unwrap();
+        let input = BcryptInput::new(cost, salt);
+
+        let err = BcryptHasher.hash(input, &[]).unwrap_err();
+
+        assert_eq!(
+            HshErr::UnsuportedStrLength(
+                String::from(
+                    "input string for bcrypt hash function must be between 0 and 72 bytes"
+                )
+            ),
+            err
+        );
+    }
+
+    #[test]
+    fn test_bcrypt_hash_long_bytes() {
+        let cost = 10;
+        let salt = Salt::from_hex("07040205070206130100030306040221").unwrap();
+        let input = BcryptInput::new(cost, salt);
+
+        let bytes = [0; 75];
+
+        let err = BcryptHasher.hash(input, &bytes).unwrap_err();
+
+        assert_eq!(
+            HshErr::UnsuportedStrLength(
+                String::from(
+                    "input string for bcrypt hash function must be between 0 and 72 bytes"
+                )
+            ),
+            err
         );
     }
 
@@ -240,8 +686,8 @@ mod test {
                 assert_eq!(vec, res.unwrap().0.to_vec());
             } else {
                 assert_eq!(
-                    HshErr::InvalidSalt(format!(
-                        "incorrect salt length (should be 16 bytes, found {})",
+                    HshErr::IncorrectSaltLength(format!(
+                        "should be 16 bytes, found {}",
                         len
                     )),
                     res.unwrap_err(),
@@ -250,35 +696,99 @@ mod test {
         }
 
         #[test]
-        fn fuzz_salt_from_str_does_not_panic(str in ".*") {
-            let _ = Salt::from_str(&str);
+        fn fuzz_salt_from_bytes_does_not_panic(str in ".*") {
+            let _ = Salt::from_bytes(&str);
         }
 
         #[test]
-        fn fuzz_salt_from_str_arbitrary_valid_hex(arr in [any::<u8>(); 16]) {
-            let hex = hex::encode(arr);
-            let salt = Salt::from_str(&hex).unwrap();
+        fn fuzz_salt_from_hex_does_not_panic(str in ".*") {
+            let _ = Salt::from_hex(&str);
+        }
+
+        #[test]
+        fn fuzz_salt_from_base64_does_not_panic(str in ".*") {
+            let _ = Salt::from_base64(&str);
+        }
+
+        #[test]
+        fn fuzz_salt_from_bytes_arbitrary_valid_bytes(arr in [any::<u8>(); 16]) {
+            let mut bytes = String::with_capacity(65);
+            bytes.push('[');
+            bytes.push_str(&arr[0].to_string());
+            for b in &arr[1..] {
+                bytes.push(',');
+                bytes.push_str(&b.to_string());
+            }
+            bytes.push(']');
+
+            let salt = Salt::from_bytes(&bytes).unwrap();
             assert_eq!(arr, salt.0);
         }
 
         #[test]
-        fn fuzz_salt_from_str_odd_length(hex in "[0-9a-f]([0-9a-f][0-9a-f])*") {
-            let err = Salt::from_str(&hex).unwrap_err();
-            assert_eq!(HshErr::InvalidSaltHex(hex::FromHexError::OddLength), err);
+        fn fuzz_salt_from_bytes_invalid_digits(input in "([a-zA-Z]+,)+") {
+            let err = Salt::from_bytes(&format!("[{}]", input)).unwrap_err();
+            let msg = format!("{}", err);
+            assert!(msg.contains("error parsing salt: invalid string"));
+            assert!(msg.contains("in byte input"));
         }
 
         #[test]
-        fn fuzz_salt_from_str_invalid_characters(hex in "([g-zG-Z][g-zG-Z])+") {
-            let err = Salt::from_str(&hex).unwrap_err();
-            let err_msg = format!("{}", err);
-            assert!(err_msg.contains("invalid salt hex -- Invalid character"));
+        fn fuzz_salt_from_bytes_invalid_format(input in "[0-9a-zA-Z]*") {
+            let err = Salt::from_bytes(&input).unwrap_err();
+            assert_eq!(HshErr::SaltFromStrError(String::from("invalid format for salt byte input")), err);
+        }
+
+        #[test]
+        fn fuzz_salt_from_hex_arbitrary_valid_hex(arr in [any::<u8>(); 16]) {
+            let hex = hex::encode(arr);
+            let salt = Salt::from_hex(&hex).unwrap();
+            assert_eq!(arr, salt.0);
+        }
+
+        #[test]
+        fn fuzz_salt_from_hex_odd_length(hex in "[0-9a-f]([0-9a-f][0-9a-f])*") {
+            let err = Salt::from_hex(&hex).unwrap_err();
+            assert_eq!(HshErr::SaltFromStrError(String::from("hex must be of even digits")), err);
+        }
+
+        #[test]
+        fn fuzz_salt_from_hex_invalid_characters(hex in "([g-zG-Z][g-zG-Z])+") {
+            let err = Salt::from_hex(&hex).unwrap_err();
+            let msg = format!("{}", err);
+            assert!(msg.contains("hex contains illegal character"));
+        }
+
+        #[test]
+        fn fuzz_salt_from_base64_arbitrary_valid_base64(arr in [any::<u8>(); 16]) {
+            let base64 = arr.to_base64(Config {
+                char_set: CharacterSet::Standard,
+                newline: Newline::LF,
+                pad: true,
+                line_length: None,
+            });
+            let salt = Salt::from_base64(&base64).unwrap();
+            assert_eq!(arr, salt.0)
+        }
+
+        #[test]
+        fn fuzz_salt_from_base64_invalid_length(base64 in "[0-9a-zA-Z/+=]{1,3}([0-9a-zA-Z/+=]{4})*") {
+            let err = Salt::from_base64(&base64).unwrap_err();
+            assert_eq!(HshErr::SaltFromStrError(String::from("length of base64 string must be a multiple of four")), err);
+        }
+
+        #[test]
+        fn fuzz_salt_from_base64_invalid_characters(base64 in "[!\"$%&'*,-.:;<=>?@]{4}") {
+            let err = Salt::from_base64(&base64).unwrap_err();
+            let msg = format!("{}", err);
+            assert!(msg.contains("base64 string contains illegal character"), msg);
         }
 
         #[test]
         #[ignore]
         fn fuzz_bcrypt_hash_does_not_panic(
             input in arbitrary_input(),
-            pass in ".{1,72}",
+            pass in ".*",
         ) {
             let _ = BcryptHasher.hash_str(input, &pass);
         }
@@ -287,7 +797,7 @@ mod test {
         #[ignore]
         fn fuzz_bcrypt_hash_bytes_does_not_panic(
             input in arbitrary_input(),
-            bytes in proptest::collection::vec(any::<u8>(), 1..72),
+            bytes in proptest::collection::vec(any::<u8>(), 0..1000),
         ) {
             let _ = BcryptHasher.hash(input, &bytes);
         }

--- a/src/blake2/mod.rs
+++ b/src/blake2/mod.rs
@@ -2,6 +2,7 @@
 use blake2::{Blake2b, Digest};
 
 // Internal imports
+use crate::error::HshResult;
 use crate::hasher::Hasher;
 use crate::types::HashOutput;
 
@@ -10,10 +11,10 @@ pub struct Blake2Hasher;
 impl Hasher for Blake2Hasher {
     type HashInput = ();
 
-    fn hash(&self, _input: (), bytes: &[u8]) -> HashOutput {
+    fn hash(&self, _input: (), bytes: &[u8]) -> HshResult<HashOutput> {
         let mut hasher = Blake2b::new();
         hasher.update(bytes);
-        HashOutput::new(hasher.finalize())
+        Ok(HashOutput::new(hasher.finalize()))
     }
 }
 
@@ -26,7 +27,7 @@ mod test {
     fn test_blake2_hash_password() {
         let password = "password";
 
-        let hash = Blake2Hasher.hash_str((), password);
+        let hash = Blake2Hasher.hash_str((), password).unwrap();
 
         assert_eq!("7c863950ac93c93692995e4732ce1e1466ad74a775352ffbaaf2a4a4ce9b549d0b414a1f3150452be6c7c72c694a7cb46f76452917298d33e67611f0a42addb8", hash.as_hex());
     }
@@ -35,7 +36,7 @@ mod test {
     fn test_blake2_hash_bytes() {
         let bytes = b"password";
 
-        let hash = Blake2Hasher.hash((), bytes);
+        let hash = Blake2Hasher.hash((), bytes).unwrap();
 
         assert_eq!("7c863950ac93c93692995e4732ce1e1466ad74a775352ffbaaf2a4a4ce9b549d0b414a1f3150452be6c7c72c694a7cb46f76452917298d33e67611f0a42addb8", hash.as_hex());
     }
@@ -51,6 +52,18 @@ mod test {
             bytes in proptest::collection::vec(any::<u8>(), 0..1000)
         ) {
             let _ = Blake2Hasher.hash((), &bytes);
+        }
+
+        #[test]
+        fn fuzz_blake2_hash_returns_ok(pass in ".*") {
+            Blake2Hasher.hash_str((), &pass).unwrap();
+        }
+
+        #[test]
+        fn fuzz_blake2_hash_bytes_returns_ok(
+            bytes in proptest::collection::vec(any::<u8>(), 0..1000)
+        ) {
+            Blake2Hasher.hash((), &bytes).unwrap();
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,10 +14,16 @@ pub enum HshErr {
 impl Display for HshErr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            HshErr::IncorrectSaltLength(msg) => f.write_str(&format!("incorrect salt length ({})", msg)),
-            HshErr::InvalidHashFunction(func) => f.write_str(&format!("invalid hash function '{}'", func)),
+            HshErr::IncorrectSaltLength(msg) => {
+                f.write_str(&format!("incorrect salt length ({})", msg))
+            }
+            HshErr::InvalidHashFunction(func) => {
+                f.write_str(&format!("invalid hash function '{}'", func))
+            }
             HshErr::SaltFromStrError(msg) => f.write_str(&format!("error parsing salt: {}", msg)),
-            HshErr::UnsuportedStrLength(msg) => f.write_str(&format!("unsuported string length ({})", msg)),
+            HshErr::UnsuportedStrLength(msg) => {
+                f.write_str(&format!("unsuported string length ({})", msg))
+            }
         }
     }
 }

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,0 +1,245 @@
+// Std imports
+use std::sync::{Mutex, MutexGuard};
+
+// External imports
+use lazy_static::lazy_static;
+
+// Internal imports
+use crate::types::Format;
+
+lazy_static! {
+    pub static ref FORMAT_MODE: FormatMode = FormatMode::new();
+}
+
+#[derive(Debug)]
+pub struct FormatMode(Mutex<FormatModeInner>);
+
+impl FormatMode {
+    fn new() -> Self {
+        Self(Mutex::new(FormatModeInner::new()))
+    }
+
+    pub fn init(&self, format: Format, salt_format: Format) {
+        self.lock().init(format, salt_format)
+    }
+
+    fn set(&self, format: Format, salt_format: Format) {
+        self.lock().set(format, salt_format);
+    }
+
+    pub fn format(&self) -> Format {
+        self.lock().format()
+    }
+
+    pub fn salt_format(&self) -> Format {
+        self.lock().salt_format()
+    }
+
+    fn lock(&self) -> MutexGuard<FormatModeInner> {
+        self.0.lock().unwrap_or_else(|err| err.into_inner())
+    }
+
+    pub fn test_with_formats<F: FnOnce() -> ()>(&self, format: Format, salt_format: Format, test: F) {
+        self.set(format, salt_format);
+        test();
+    }
+
+    pub fn test_with_salt_format<F: FnOnce() -> ()>(&self, salt_format: Format, test: F) {
+        self.test_with_formats(Format::Hex, salt_format, test);
+    }
+}
+
+#[derive(Debug)]
+struct FormatModeInner {
+    format: Option<Format>,
+    salt_format: Option<Format>,
+}
+
+impl FormatModeInner {
+    fn new() -> Self {
+        Self { format: None, salt_format: None }
+    }
+
+    fn is_initialised(&self) -> bool {
+        self.format.is_some() && self.salt_format.is_some()
+    }
+
+    fn init(&mut self, format: Format, salt_format: Format) {
+        debug_assert!(!self.is_initialised(), "FORMAT_MODE already initialised");
+
+        self.set(format, salt_format);
+    }
+
+    fn set(&mut self, format: Format, salt_format: Format) {
+        self.format = Some(format);
+        self.salt_format = Some(salt_format);
+    }
+
+    fn format(&self) -> Format {
+        debug_assert!(self.is_initialised(), "FORMAT_MODE not yet initialised");
+
+        self.format.unwrap()
+    }
+
+    fn salt_format(&self) -> Format {
+        debug_assert!(self.is_initialised(), "FORMAT_MODE not yet initialised");
+
+        self.salt_format.unwrap()
+    }
+}
+
+pub fn get_format() -> Format {
+    FORMAT_MODE.format()
+}
+
+pub fn get_salt_format() -> Format {
+    FORMAT_MODE.salt_format()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_format_mode_inner_new() {
+        let inner = FormatModeInner::new();
+        assert_eq!(None, inner.format);
+        assert_eq!(None, inner.salt_format);
+    }
+
+    #[test]
+    fn test_format_mode_inner_is_initialised() {
+        let mut inner = FormatModeInner::new();
+        assert!(!inner.is_initialised());
+        inner.init(Format::Hex, Format::Hex);
+        assert!(inner.is_initialised());
+    }
+
+    #[test]
+    fn test_format_mode_inner_init() {
+        let mut inner = FormatModeInner::new();
+        inner.init(Format::Bytes, Format::Base64);
+        assert_eq!(Format::Bytes, inner.format.unwrap());
+        assert_eq!(Format::Base64, inner.salt_format.unwrap());
+    }
+
+    #[test]
+    #[should_panic(expected = "FORMAT_MODE already initialised")]
+    fn test_format_mode_inner_init_twice_should_panic() {
+        let mut inner = FormatModeInner::new();
+        inner.init(Format::Hex, Format::Hex);
+        inner.init(Format::Base64, Format::Base64);
+    }
+
+    #[test]
+    fn test_format_mode_inner_set() {
+        let mut inner = FormatModeInner::new();
+        inner.init(Format::Hex, Format::Hex);
+        inner.set(Format::Base64, Format::Bytes);
+        assert_eq!(Format::Base64, inner.format.unwrap());
+        assert_eq!(Format::Bytes, inner.salt_format.unwrap());
+    }
+
+    #[test]
+    #[should_panic(expected = "FORMAT_MODE not yet initialised")]
+    fn test_format_mode_inner_get_format_uninitialised_should_panic() {
+        let inner = FormatModeInner::new();
+        inner.format();
+    }
+
+    #[test]
+    #[should_panic(expected = "FORMAT_MODE not yet initialised")]
+    fn test_format_mode_inner_get_salt_format_uninitialised_should_panic() {
+        let inner = FormatModeInner::new();
+        inner.salt_format();
+    }
+
+    #[test]
+    fn test_format_mode_inner_get_format() {
+        let mut inner = FormatModeInner::new();
+        inner.init(Format::Bytes, Format::Hex);
+        assert_eq!(Format::Bytes, inner.format());
+    }
+
+    #[test]
+    fn test_format_mode_inner_get_salt_format() {
+        let mut inner = FormatModeInner::new();
+        inner.init(Format::Hex, Format::Base64);
+        assert_eq!(Format::Base64, inner.salt_format());
+    }
+
+    #[test]
+    fn test_format_mode_init() {
+        let mode = FormatMode::new();
+        mode.init(Format::Base64, Format::Bytes);
+        assert_eq!(Format::Base64, mode.format());
+        assert_eq!(Format::Bytes, mode.salt_format());
+    }
+
+    #[test]
+    #[should_panic(expected = "FORMAT_MODE already initialised")]
+    fn test_format_mode_init_twice_should_panic() {
+        let mode = FormatMode::new();
+        mode.init(Format::Hex, Format::Hex);
+        mode.init(Format::Base64, Format::Base64);
+    }
+
+    #[test]
+    fn test_format_mode_set() {
+        let mode = FormatMode::new();
+        mode.init(Format::Hex, Format::Hex);
+        mode.set(Format::Base64, Format::Bytes);
+        assert_eq!(Format::Base64, mode.format());
+        assert_eq!(Format::Bytes, mode.salt_format());
+    }
+
+    #[test]
+    #[should_panic(expected = "FORMAT_MODE not yet initialised")]
+    fn test_format_mode_get_format_uninitialised_should_panic() {
+        let mode = FormatMode::new();
+        mode.format();
+    }
+
+    #[test]
+    #[should_panic(expected = "FORMAT_MODE not yet initialised")]
+    fn test_format_mode_get_salt_format_uninitialised_should_panic() {
+        let mode = FormatMode::new();
+        mode.salt_format();
+    }
+
+    #[test]
+    fn test_format_mode_get_format() {
+        let mode = FormatMode::new();
+        mode.init(Format::Bytes, Format::Hex);
+        assert_eq!(Format::Bytes, mode.format());
+    }
+
+    #[test]
+    fn test_format_mode_get_salt_format() {
+        let mode = FormatMode::new();
+        mode.init(Format::Hex, Format::Base64);
+        assert_eq!(Format::Base64, mode.salt_format());
+    }
+
+    #[test]
+    fn test_format_mode_lock() {
+        let mode = FormatMode::new();
+        let _ = mode.lock();
+    }
+
+    #[test]
+    fn test_get_format() {
+        FORMAT_MODE.test_with_formats(Format::Base64, Format::Bytes, || {
+            let format = get_format();
+            assert_eq!(Format::Base64, format);
+        });
+    }
+
+    #[test]
+    fn test_get_salt_format() {
+        FORMAT_MODE.test_with_formats(Format::Base64, Format::Bytes, || {
+            let format = get_salt_format();
+            assert_eq!(Format::Bytes, format);
+        });
+    }
+}

--- a/src/format.rs
+++ b/src/format.rs
@@ -39,7 +39,7 @@ impl FormatMode {
         self.0.lock().unwrap_or_else(|err| err.into_inner())
     }
 
-    pub fn test_with_formats<F: FnOnce() -> ()>(
+    pub fn test_with_formats<F: FnOnce()>(
         &self,
         format: Format,
         salt_format: Format,
@@ -49,11 +49,11 @@ impl FormatMode {
         test();
     }
 
-    pub fn test_with_format<F: FnOnce() -> ()>(&self, format: Format, test: F) {
+    pub fn test_with_format<F: FnOnce()>(&self, format: Format, test: F) {
         self.test_with_formats(format, Format::Hex, test);
     }
 
-    pub fn test_with_salt_format<F: FnOnce() -> ()>(&self, salt_format: Format, test: F) {
+    pub fn test_with_salt_format<F: FnOnce()>(&self, salt_format: Format, test: F) {
         self.test_with_formats(Format::Hex, salt_format, test);
     }
 }

--- a/src/format.rs
+++ b/src/format.rs
@@ -49,6 +49,10 @@ impl FormatMode {
         test();
     }
 
+    pub fn test_with_format<F: FnOnce() -> ()>(&self, format: Format, test: F) {
+        self.test_with_formats(format, Format::Hex, test);
+    }
+
     pub fn test_with_salt_format<F: FnOnce() -> ()>(&self, salt_format: Format, test: F) {
         self.test_with_formats(Format::Hex, salt_format, test);
     }

--- a/src/format.rs
+++ b/src/format.rs
@@ -39,7 +39,12 @@ impl FormatMode {
         self.0.lock().unwrap_or_else(|err| err.into_inner())
     }
 
-    pub fn test_with_formats<F: FnOnce() -> ()>(&self, format: Format, salt_format: Format, test: F) {
+    pub fn test_with_formats<F: FnOnce() -> ()>(
+        &self,
+        format: Format,
+        salt_format: Format,
+        test: F,
+    ) {
         self.set(format, salt_format);
         test();
     }
@@ -57,7 +62,10 @@ struct FormatModeInner {
 
 impl FormatModeInner {
     fn new() -> Self {
-        Self { format: None, salt_format: None }
+        Self {
+            format: None,
+            salt_format: None,
+        }
     }
 
     fn is_initialised(&self) -> bool {

--- a/src/groestl/groestl384.rs
+++ b/src/groestl/groestl384.rs
@@ -2,6 +2,7 @@
 use groestl::{Digest, Groestl384};
 
 // Internal imports
+use crate::error::HshResult;
 use crate::hasher::Hasher;
 use crate::types::HashOutput;
 
@@ -10,10 +11,10 @@ pub struct Groestl384Hasher;
 impl Hasher for Groestl384Hasher {
     type HashInput = ();
 
-    fn hash(&self, _input: (), bytes: &[u8]) -> HashOutput {
+    fn hash(&self, _input: (), bytes: &[u8]) -> HshResult<HashOutput> {
         let mut hasher = Groestl384::new();
         hasher.update(bytes);
-        HashOutput::new(hasher.finalize())
+        Ok(HashOutput::new(hasher.finalize()))
     }
 }
 
@@ -26,7 +27,7 @@ mod test {
     fn test_groestl384_hash_password() {
         let password = "password";
 
-        let hash = Groestl384Hasher.hash_str((), password);
+        let hash = Groestl384Hasher.hash_str((), password).unwrap();
 
         assert_eq!("689cc12d7c232ab2503cc596b4973ea1e7b75361cfbbfd947c92ef02b65b5b1ca71c4391d3c50f3d092481d6ba459b13", hash.as_hex());
     }
@@ -35,7 +36,7 @@ mod test {
     fn test_groestl384_hash_bytes() {
         let bytes = b"password";
 
-        let hash = Groestl384Hasher.hash((), bytes);
+        let hash = Groestl384Hasher.hash((), bytes).unwrap();
 
         assert_eq!("689cc12d7c232ab2503cc596b4973ea1e7b75361cfbbfd947c92ef02b65b5b1ca71c4391d3c50f3d092481d6ba459b13", hash.as_hex());
     }
@@ -51,6 +52,18 @@ mod test {
             bytes in proptest::collection::vec(any::<u8>(), 0..1000)
         ) {
             let _ = Groestl384Hasher.hash((), &bytes);
+        }
+
+        #[test]
+        fn fuzz_groestl384_hash_returns_ok(pass in ".*") {
+            Groestl384Hasher.hash_str((), &pass).unwrap();
+        }
+
+        #[test]
+        fn fuzz_groestl384_hash_bytes_returns_ok(
+            bytes in proptest::collection::vec(any::<u8>(), 0..1000)
+        ) {
+            Groestl384Hasher.hash((), &bytes).unwrap();
         }
     }
 }

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -1,12 +1,13 @@
 // Internal imports
+use crate::error::HshResult;
 use crate::types::HashOutput;
 
 pub trait Hasher {
     type HashInput;
 
-    fn hash(&self, input: Self::HashInput, bytes: &[u8]) -> HashOutput;
+    fn hash(&self, input: Self::HashInput, bytes: &[u8]) -> HshResult<HashOutput>;
 
-    fn hash_str(&self, input: Self::HashInput, str: &str) -> HashOutput {
+    fn hash_str(&self, input: Self::HashInput, str: &str) -> HshResult<HashOutput> {
         self.hash(input, &str.as_bytes())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,4 @@
 // Modules
-mod error;
-mod hasher;
-
 mod bcrypt;
 mod blake2;
 mod gost94;
@@ -50,11 +47,15 @@ mod streebog {
 mod whirlpool;
 
 // Public modules
+pub mod error;
+pub mod format;
+pub mod hasher;
 pub mod types;
 
 // Internal imports
 use crate::bcrypt::{BcryptHasher, BcryptInput};
 use crate::blake2::Blake2Hasher;
+use crate::error::HshResult;
 use crate::gost94::{Gost94Hasher, SBox};
 use crate::groestl::{
     groestl224::Groestl224Hasher, groestl256::Groestl256Hasher, groestl384::Groestl384Hasher,
@@ -87,7 +88,7 @@ pub fn hash(
     function: HashFunction,
     cost: Option<u32>,
     salt: Option<Salt>,
-) -> HashOutput {
+) -> HshResult<HashOutput> {
     use crate::types::HashFunction::*;
 
     match function {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-// Lib imports
+// Std imports
 use std::str::FromStr;
 
 // External imports

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,11 +55,6 @@ fn parse_salt(opt: &Opt) -> HshResult<Option<Salt>> {
     if opt.salt.is_none() {
         Ok(None)
     } else {
-        let res = Salt::from_str(&opt.salt.clone().unwrap());
-        if res.is_ok() {
-            Ok(Some(res.unwrap()))
-        } else {
-            Err(res.unwrap_err())
-        }
+        Ok(Some(Salt::from_str(&opt.salt.clone().unwrap())?))
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,8 +24,10 @@ struct Opt {
     /// The 16-byte salt to use when hashing with the Bcrypt hash function
     #[structopt(short, long, required_if("function", "bcrypt"))]
     salt: Option<String>,
-    #[structopt(short, long, env="HSH_FORMAT", possible_values = &Format::variants(), case_insensitive=true, default_value="hex")]
+    /// The format in which to display the output hash
+    #[structopt(long, env="HSH_FORMAT", possible_values = &Format::variants(), case_insensitive=true, default_value="hex")]
     format: Format,
+    /// The format of the salt argument (defaults to the value of `format`)
     #[structopt(long, env="SALT_FORMAT", possible_values = &Format::variants(), case_insensitive=true)]
     salt_format: Option<Format>,
 }

--- a/src/ripemd/ripemd160.rs
+++ b/src/ripemd/ripemd160.rs
@@ -2,6 +2,7 @@
 use ripemd160::{Digest, Ripemd160};
 
 // Internal imports
+use crate::error::HshResult;
 use crate::hasher::Hasher;
 use crate::types::HashOutput;
 
@@ -10,10 +11,10 @@ pub struct Ripemd160Hasher;
 impl Hasher for Ripemd160Hasher {
     type HashInput = ();
 
-    fn hash(&self, _input: (), bytes: &[u8]) -> HashOutput {
+    fn hash(&self, _input: (), bytes: &[u8]) -> HshResult<HashOutput> {
         let mut hasher = Ripemd160::new();
         hasher.update(bytes);
-        HashOutput::new(hasher.finalize())
+        Ok(HashOutput::new(hasher.finalize()))
     }
 }
 
@@ -26,7 +27,7 @@ mod test {
     fn test_ripemd160_hash_password() {
         let password = "password";
 
-        let hash = Ripemd160Hasher.hash_str((), password);
+        let hash = Ripemd160Hasher.hash_str((), password).unwrap();
 
         assert_eq!("2c08e8f5884750a7b99f6f2f342fc638db25ff31", hash.as_hex());
     }
@@ -35,7 +36,7 @@ mod test {
     fn test_ripemd160_hash_bytes() {
         let bytes = b"password";
 
-        let hash = Ripemd160Hasher.hash((), bytes);
+        let hash = Ripemd160Hasher.hash((), bytes).unwrap();
 
         assert_eq!("2c08e8f5884750a7b99f6f2f342fc638db25ff31", hash.as_hex());
     }
@@ -51,6 +52,18 @@ mod test {
             bytes in proptest::collection::vec(any::<u8>(), 0..1000)
         ) {
             let _ = Ripemd160Hasher.hash((), &bytes);
+        }
+
+        #[test]
+        fn fuzz_ripemd160_hash_returns_ok(pass in ".*") {
+            Ripemd160Hasher.hash_str((), &pass).unwrap();
+        }
+
+        #[test]
+        fn fuzz_ripemd160_hash_bytes_returns_ok(
+            bytes in proptest::collection::vec(any::<u8>(), 0..1000)
+        ) {
+            Ripemd160Hasher.hash((), &bytes).unwrap();
         }
     }
 }

--- a/src/ripemd/ripemd320.rs
+++ b/src/ripemd/ripemd320.rs
@@ -2,6 +2,7 @@
 use ripemd320::{Digest, Ripemd320};
 
 // Internal imports
+use crate::error::HshResult;
 use crate::hasher::Hasher;
 use crate::types::HashOutput;
 
@@ -10,10 +11,10 @@ pub struct Ripemd320Hasher;
 impl Hasher for Ripemd320Hasher {
     type HashInput = ();
 
-    fn hash(&self, _input: (), bytes: &[u8]) -> HashOutput {
+    fn hash(&self, _input: (), bytes: &[u8]) -> HshResult<HashOutput> {
         let mut hasher = Ripemd320::new();
         hasher.update(bytes);
-        HashOutput::new(hasher.finalize())
+        Ok(HashOutput::new(hasher.finalize()))
     }
 }
 
@@ -26,7 +27,7 @@ mod test {
     fn test_ripemd320_hash_password() {
         let password = "password";
 
-        let hash = Ripemd320Hasher.hash_str((), password);
+        let hash = Ripemd320Hasher.hash_str((), password).unwrap();
 
         assert_eq!(
             "c571d82e535de67ff5f87e417b3d53125f2d83ed7598b89d74483e6c0dfe8d86e88b380249fc8fb4",
@@ -38,7 +39,7 @@ mod test {
     fn test_ripemd320_hash_bytes() {
         let bytes = b"password";
 
-        let hash = Ripemd320Hasher.hash((), bytes);
+        let hash = Ripemd320Hasher.hash((), bytes).unwrap();
 
         assert_eq!(
             "c571d82e535de67ff5f87e417b3d53125f2d83ed7598b89d74483e6c0dfe8d86e88b380249fc8fb4",
@@ -57,6 +58,18 @@ mod test {
             bytes in proptest::collection::vec(any::<u8>(), 0..1000)
         ) {
             let _ = Ripemd320Hasher.hash((), &bytes);
+        }
+
+        #[test]
+        fn fuzz_ripemd320_hash_returns_ok(pass in ".*") {
+            Ripemd320Hasher.hash_str((), &pass).unwrap();
+        }
+
+        #[test]
+        fn fuzz_ripemd320_hash_bytes_returns_ok(
+            bytes in proptest::collection::vec(any::<u8>(), 0..1000)
+        ) {
+            Ripemd320Hasher.hash((), &bytes).unwrap();
         }
     }
 }

--- a/src/sha2/sha224.rs
+++ b/src/sha2/sha224.rs
@@ -2,6 +2,7 @@
 use sha2::{Digest, Sha224};
 
 // Internal imports
+use crate::error::HshResult;
 use crate::hasher::Hasher;
 use crate::types::HashOutput;
 
@@ -10,10 +11,10 @@ pub struct Sha224Hasher;
 impl Hasher for Sha224Hasher {
     type HashInput = ();
 
-    fn hash(&self, _input: (), bytes: &[u8]) -> HashOutput {
+    fn hash(&self, _input: (), bytes: &[u8]) -> HshResult<HashOutput> {
         let mut hasher = Sha224::new();
         hasher.update(bytes);
-        HashOutput::new(hasher.finalize())
+        Ok(HashOutput::new(hasher.finalize()))
     }
 }
 
@@ -26,7 +27,7 @@ mod test {
     fn test_sha224_hash_password() {
         let password = "password";
 
-        let hash = Sha224Hasher.hash_str((), password);
+        let hash = Sha224Hasher.hash_str((), password).unwrap();
 
         assert_eq!(
             "d63dc919e201d7bc4c825630d2cf25fdc93d4b2f0d46706d29038d01",
@@ -38,7 +39,7 @@ mod test {
     fn test_sha224_hash_bytes() {
         let bytes = b"password";
 
-        let hash = Sha224Hasher.hash((), bytes);
+        let hash = Sha224Hasher.hash((), bytes).unwrap();
 
         assert_eq!(
             "d63dc919e201d7bc4c825630d2cf25fdc93d4b2f0d46706d29038d01",
@@ -57,6 +58,18 @@ mod test {
             bytes in proptest::collection::vec(any::<u8>(), 0..1000)
         ) {
             let _ = Sha224Hasher.hash((), &bytes);
+        }
+
+        #[test]
+        fn fuzz_sha224_hash_returns_ok(pass in ".*") {
+            Sha224Hasher.hash_str((), &pass).unwrap();
+        }
+
+        #[test]
+        fn fuzz_sha224_hash_bytes_returns_ok(
+            bytes in proptest::collection::vec(any::<u8>(), 0..1000)
+        ) {
+            Sha224Hasher.hash((), &bytes).unwrap();
         }
     }
 }

--- a/src/sha3/keccak224.rs
+++ b/src/sha3/keccak224.rs
@@ -2,6 +2,7 @@
 use sha3::{Digest, Keccak224};
 
 // Internal imports
+use crate::error::HshResult;
 use crate::hasher::Hasher;
 use crate::types::HashOutput;
 
@@ -10,10 +11,10 @@ pub struct Keccak224Hasher;
 impl Hasher for Keccak224Hasher {
     type HashInput = ();
 
-    fn hash(&self, _input: (), bytes: &[u8]) -> HashOutput {
+    fn hash(&self, _input: (), bytes: &[u8]) -> HshResult<HashOutput> {
         let mut hasher = Keccak224::new();
         hasher.update(bytes);
-        HashOutput::new(hasher.finalize())
+        Ok(HashOutput::new(hasher.finalize()))
     }
 }
 
@@ -26,7 +27,7 @@ mod test {
     fn test_keccak224_hash_password() {
         let password = "password";
 
-        let hash = Keccak224Hasher.hash_str((), password);
+        let hash = Keccak224Hasher.hash_str((), password).unwrap();
 
         assert_eq!(
             "12cfa398e1a905fe361713aa798b5a77655980cee83b4dd57ec8c595",
@@ -38,7 +39,7 @@ mod test {
     fn test_keccak224_hash_bytes() {
         let bytes = b"password";
 
-        let hash = Keccak224Hasher.hash((), bytes);
+        let hash = Keccak224Hasher.hash((), bytes).unwrap();
 
         assert_eq!(
             "12cfa398e1a905fe361713aa798b5a77655980cee83b4dd57ec8c595",
@@ -57,6 +58,18 @@ mod test {
             bytes in proptest::collection::vec(any::<u8>(), 0..1000)
         ) {
             let _ = Keccak224Hasher.hash((), &bytes);
+        }
+
+        #[test]
+        fn fuzz_keccak224_hash_returns_ok(pass in ".*") {
+            Keccak224Hasher.hash_str((), &pass).unwrap();
+        }
+
+        #[test]
+        fn fuzz_keccak224_hash_bytes_returns_ok(
+            bytes in proptest::collection::vec(any::<u8>(), 0..1000)
+        ) {
+            Keccak224Hasher.hash((), &bytes).unwrap();
         }
     }
 }

--- a/src/sha3/keccak256full.rs
+++ b/src/sha3/keccak256full.rs
@@ -2,6 +2,7 @@
 use sha3::{Digest, Keccak256Full};
 
 // Internal imports
+use crate::error::HshResult;
 use crate::hasher::Hasher;
 use crate::types::HashOutput;
 
@@ -10,10 +11,10 @@ pub struct Keccak256FullHasher;
 impl Hasher for Keccak256FullHasher {
     type HashInput = ();
 
-    fn hash(&self, _input: (), bytes: &[u8]) -> HashOutput {
+    fn hash(&self, _input: (), bytes: &[u8]) -> HshResult<HashOutput> {
         let mut hasher = Keccak256Full::new();
         hasher.update(bytes);
-        HashOutput::new(hasher.finalize())
+        Ok(HashOutput::new(hasher.finalize()))
     }
 }
 
@@ -26,7 +27,7 @@ mod test {
     fn test_keccak256_full_hash_password() {
         let password = "password";
 
-        let hash = Keccak256FullHasher.hash_str((), password);
+        let hash = Keccak256FullHasher.hash_str((), password).unwrap();
 
         assert_eq!("b68fe43f0d1a0d7aef123722670be50268e15365401c442f8806ef83b612976b35076a9404c654b79f6590d0c41e130dabc93bdc37397e1d0bf1921c3c5a267332e2ceca4535a6f04ea73f2986cec5dcafc05b7d4b5495ab5fb1aaf3650f0713c7d9280508b3c9271698856e7521f8d91e0ad1d83f44a133c4db87ecb4af53b53868807dd3c1827acf2b2cccfcb2cb69e337d98eb56fecd2559310b9dd015bed94c993c0cad1bf73a328f6891c1b29c4935ed787fa9ef40b860eab776ff77f4a870966e58c894687", hash.as_hex());
     }
@@ -35,7 +36,7 @@ mod test {
     fn test_keccak256_full_hash_bytes() {
         let bytes = b"password";
 
-        let hash = Keccak256FullHasher.hash((), bytes);
+        let hash = Keccak256FullHasher.hash((), bytes).unwrap();
 
         assert_eq!("b68fe43f0d1a0d7aef123722670be50268e15365401c442f8806ef83b612976b35076a9404c654b79f6590d0c41e130dabc93bdc37397e1d0bf1921c3c5a267332e2ceca4535a6f04ea73f2986cec5dcafc05b7d4b5495ab5fb1aaf3650f0713c7d9280508b3c9271698856e7521f8d91e0ad1d83f44a133c4db87ecb4af53b53868807dd3c1827acf2b2cccfcb2cb69e337d98eb56fecd2559310b9dd015bed94c993c0cad1bf73a328f6891c1b29c4935ed787fa9ef40b860eab776ff77f4a870966e58c894687", hash.as_hex());
     }
@@ -51,6 +52,18 @@ mod test {
             bytes in proptest::collection::vec(any::<u8>(), 0..1000)
         ) {
             let _ = Keccak256FullHasher.hash((), &bytes);
+        }
+
+        #[test]
+        fn fuzz_keccak256_full_hash_returns_ok(pass in ".*") {
+            Keccak256FullHasher.hash_str((), &pass).unwrap();
+        }
+
+        #[test]
+        fn fuzz_keccak256_full_hash_bytes_returns_ok(
+            bytes in proptest::collection::vec(any::<u8>(), 0..1000)
+        ) {
+            Keccak256FullHasher.hash((), &bytes).unwrap();
         }
     }
 }

--- a/src/sha3/keccak512.rs
+++ b/src/sha3/keccak512.rs
@@ -2,6 +2,7 @@
 use sha3::{Digest, Keccak512};
 
 // Internal imports
+use crate::error::HshResult;
 use crate::hasher::Hasher;
 use crate::types::HashOutput;
 
@@ -10,10 +11,10 @@ pub struct Keccak512Hasher;
 impl Hasher for Keccak512Hasher {
     type HashInput = ();
 
-    fn hash(&self, _input: (), bytes: &[u8]) -> HashOutput {
+    fn hash(&self, _input: (), bytes: &[u8]) -> HshResult<HashOutput> {
         let mut hasher = Keccak512::new();
         hasher.update(bytes);
-        HashOutput::new(hasher.finalize())
+        Ok(HashOutput::new(hasher.finalize()))
     }
 }
 
@@ -26,7 +27,7 @@ mod test {
     fn test_keccak512_hash_password() {
         let password = "password";
 
-        let hash = Keccak512Hasher.hash_str((), password);
+        let hash = Keccak512Hasher.hash_str((), password).unwrap();
 
         assert_eq!("a6818b8188b36c44d17784c5551f63accc5deaf8786f9d0ad1ae3cd8d887cbab4f777286dbb315fb14854c8774dc0d10b5567e4a705536cc2a1d61ec0a16a7a6", hash.as_hex());
     }
@@ -35,7 +36,7 @@ mod test {
     fn test_keccak512_hash_bytes() {
         let bytes = b"password";
 
-        let hash = Keccak512Hasher.hash((), bytes);
+        let hash = Keccak512Hasher.hash((), bytes).unwrap();
 
         assert_eq!("a6818b8188b36c44d17784c5551f63accc5deaf8786f9d0ad1ae3cd8d887cbab4f777286dbb315fb14854c8774dc0d10b5567e4a705536cc2a1d61ec0a16a7a6", hash.as_hex());
     }
@@ -51,6 +52,18 @@ mod test {
             bytes in proptest::collection::vec(any::<u8>(), 0..1000)
         ) {
             let _ = Keccak512Hasher.hash((), &bytes);
+        }
+
+        #[test]
+        fn fuzz_keccak512_hash_returns_ok(pass in ".*") {
+            Keccak512Hasher.hash_str((), &pass).unwrap();
+        }
+
+        #[test]
+        fn fuzz_keccak512_hash_bytes_returns_ok(
+            bytes in proptest::collection::vec(any::<u8>(), 0..1000)
+        ) {
+            Keccak512Hasher.hash((), &bytes).unwrap();
         }
     }
 }

--- a/src/sha3/sha3_224.rs
+++ b/src/sha3/sha3_224.rs
@@ -2,6 +2,7 @@
 use sha3::{Digest, Sha3_224};
 
 // Internal imports
+use crate::error::HshResult;
 use crate::hasher::Hasher;
 use crate::types::HashOutput;
 
@@ -10,10 +11,10 @@ pub struct Sha3_224Hasher;
 impl Hasher for Sha3_224Hasher {
     type HashInput = ();
 
-    fn hash(&self, _input: (), bytes: &[u8]) -> HashOutput {
+    fn hash(&self, _input: (), bytes: &[u8]) -> HshResult<HashOutput> {
         let mut hasher = Sha3_224::new();
         hasher.update(bytes);
-        HashOutput::new(hasher.finalize())
+        Ok(HashOutput::new(hasher.finalize()))
     }
 }
 
@@ -26,7 +27,7 @@ mod test {
     fn test_sha3_224_hash_password() {
         let password = "password";
 
-        let hash = Sha3_224Hasher.hash_str((), password);
+        let hash = Sha3_224Hasher.hash_str((), password).unwrap();
 
         assert_eq!(
             "c3f847612c3780385a859a1993dfd9fe7c4e6d7f477148e527e9374c",
@@ -38,7 +39,7 @@ mod test {
     fn test_sha3_224_hash_bytes() {
         let bytes = b"password";
 
-        let hash = Sha3_224Hasher.hash((), bytes);
+        let hash = Sha3_224Hasher.hash((), bytes).unwrap();
 
         assert_eq!(
             "c3f847612c3780385a859a1993dfd9fe7c4e6d7f477148e527e9374c",
@@ -57,6 +58,18 @@ mod test {
             bytes in proptest::collection::vec(any::<u8>(), 0..1000)
         ) {
             let _ = Sha3_224Hasher.hash((), &bytes);
+        }
+
+        #[test]
+        fn fuzz_sha3_224_hash_returns_ok(pass in ".*") {
+            Sha3_224Hasher.hash_str((), &pass).unwrap();
+        }
+
+        #[test]
+        fn fuzz_sha3_224_hash_bytes_returns_ok(
+            bytes in proptest::collection::vec(any::<u8>(), 0..1000)
+        ) {
+            Sha3_224Hasher.hash((), &bytes).unwrap();
         }
     }
 }

--- a/src/sha3/sha3_384.rs
+++ b/src/sha3/sha3_384.rs
@@ -2,6 +2,7 @@
 use sha3::{Digest, Sha3_384};
 
 // Internal imports
+use crate::error::HshResult;
 use crate::hasher::Hasher;
 use crate::types::HashOutput;
 
@@ -10,10 +11,10 @@ pub struct Sha3_384Hasher;
 impl Hasher for Sha3_384Hasher {
     type HashInput = ();
 
-    fn hash(&self, _input: (), bytes: &[u8]) -> HashOutput {
+    fn hash(&self, _input: (), bytes: &[u8]) -> HshResult<HashOutput> {
         let mut hasher = Sha3_384::new();
         hasher.update(bytes);
-        HashOutput::new(hasher.finalize())
+        Ok(HashOutput::new(hasher.finalize()))
     }
 }
 
@@ -26,7 +27,7 @@ mod test {
     fn test_sha3_384_hash_password() {
         let password = "password";
 
-        let hash = Sha3_384Hasher.hash_str((), password);
+        let hash = Sha3_384Hasher.hash_str((), password).unwrap();
 
         assert_eq!("9c1565e99afa2ce7800e96a73c125363c06697c5674d59f227b3368fd00b85ead506eefa90702673d873cb2c9357eafc", hash.as_hex());
     }
@@ -35,7 +36,7 @@ mod test {
     fn test_sha3_384_hash_bytes() {
         let bytes = b"password";
 
-        let hash = Sha3_384Hasher.hash((), bytes);
+        let hash = Sha3_384Hasher.hash((), bytes).unwrap();
 
         assert_eq!("9c1565e99afa2ce7800e96a73c125363c06697c5674d59f227b3368fd00b85ead506eefa90702673d873cb2c9357eafc", hash.as_hex());
     }
@@ -51,6 +52,18 @@ mod test {
             bytes in proptest::collection::vec(any::<u8>(), 0..1000)
         ) {
             let _ = Sha3_384Hasher.hash((), &bytes);
+        }
+
+        #[test]
+        fn fuzz_sha3_384_hash_returns_ok(pass in ".*") {
+            Sha3_384Hasher.hash_str((), &pass).unwrap();
+        }
+
+        #[test]
+        fn fuzz_sha3_384_hash_bytes_returns_ok(
+            bytes in proptest::collection::vec(any::<u8>(), 0..1000)
+        ) {
+            Sha3_384Hasher.hash((), &bytes).unwrap();
         }
     }
 }

--- a/src/sha3/sha3_512.rs
+++ b/src/sha3/sha3_512.rs
@@ -2,6 +2,7 @@
 use sha3::{Digest, Sha3_512};
 
 // Internal imports
+use crate::error::HshResult;
 use crate::hasher::Hasher;
 use crate::types::HashOutput;
 
@@ -10,10 +11,10 @@ pub struct Sha3_512Hasher;
 impl Hasher for Sha3_512Hasher {
     type HashInput = ();
 
-    fn hash(&self, _input: (), bytes: &[u8]) -> HashOutput {
+    fn hash(&self, _input: (), bytes: &[u8]) -> HshResult<HashOutput> {
         let mut hasher = Sha3_512::new();
         hasher.update(bytes);
-        HashOutput::new(hasher.finalize())
+        Ok(HashOutput::new(hasher.finalize()))
     }
 }
 
@@ -26,7 +27,7 @@ mod test {
     fn test_sha3_512_hash_password() {
         let password = "password";
 
-        let hash = Sha3_512Hasher.hash_str((), password);
+        let hash = Sha3_512Hasher.hash_str((), password).unwrap();
 
         assert_eq!("e9a75486736a550af4fea861e2378305c4a555a05094dee1dca2f68afea49cc3a50e8de6ea131ea521311f4d6fb054a146e8282f8e35ff2e6368c1a62e909716", hash.as_hex());
     }
@@ -35,7 +36,7 @@ mod test {
     fn test_sha3_512_hash_bytes() {
         let bytes = b"password";
 
-        let hash = Sha3_512Hasher.hash((), bytes);
+        let hash = Sha3_512Hasher.hash((), bytes).unwrap();
 
         assert_eq!("e9a75486736a550af4fea861e2378305c4a555a05094dee1dca2f68afea49cc3a50e8de6ea131ea521311f4d6fb054a146e8282f8e35ff2e6368c1a62e909716", hash.as_hex());
     }
@@ -51,6 +52,18 @@ mod test {
             bytes in proptest::collection::vec(any::<u8>(), 0..1000)
         ) {
             let _ = Sha3_512Hasher.hash((), &bytes);
+        }
+
+        #[test]
+        fn fuzz_sha3_512_hash_returns_ok(pass in ".*") {
+            Sha3_512Hasher.hash_str((), &pass).unwrap();
+        }
+
+        #[test]
+        fn fuzz_sha3_512_hash_bytes_returns_ok(
+            bytes in proptest::collection::vec(any::<u8>(), 0..1000)
+        ) {
+            Sha3_512Hasher.hash((), &bytes).unwrap();
         }
     }
 }

--- a/src/shabal/shabal192.rs
+++ b/src/shabal/shabal192.rs
@@ -2,6 +2,7 @@
 use shabal::{Digest, Shabal192};
 
 // Internal imports
+use crate::error::HshResult;
 use crate::hasher::Hasher;
 use crate::types::HashOutput;
 
@@ -10,10 +11,10 @@ pub struct Shabal192Hasher;
 impl Hasher for Shabal192Hasher {
     type HashInput = ();
 
-    fn hash(&self, _input: (), bytes: &[u8]) -> HashOutput {
+    fn hash(&self, _input: (), bytes: &[u8]) -> HshResult<HashOutput> {
         let mut hasher = Shabal192::new();
         hasher.update(bytes);
-        HashOutput::new(hasher.finalize())
+        Ok(HashOutput::new(hasher.finalize()))
     }
 }
 
@@ -26,7 +27,7 @@ mod test {
     fn test_shabal192_hash_password() {
         let password = "password";
 
-        let hash = Shabal192Hasher.hash_str((), password);
+        let hash = Shabal192Hasher.hash_str((), password).unwrap();
 
         assert_eq!(
             "50d3d99549fc5f75bfae91e632f551a6bec000a3c3a5cfe7",
@@ -38,7 +39,7 @@ mod test {
     fn test_shabal192_hash_bytes() {
         let bytes = b"password";
 
-        let hash = Shabal192Hasher.hash((), bytes);
+        let hash = Shabal192Hasher.hash((), bytes).unwrap();
 
         assert_eq!(
             "50d3d99549fc5f75bfae91e632f551a6bec000a3c3a5cfe7",
@@ -57,6 +58,18 @@ mod test {
             bytes in proptest::collection::vec(any::<u8>(), 0..1000)
         ) {
             let _ = Shabal192Hasher.hash((), &bytes);
+        }
+
+        #[test]
+        fn fuzz_shabal192_hash_returns_ok(pass in ".*") {
+            Shabal192Hasher.hash_str((), &pass).unwrap();
+        }
+
+        #[test]
+        fn fuzz_shabal192_hash_bytes_returns_ok(
+            bytes in proptest::collection::vec(any::<u8>(), 0..1000)
+        ) {
+            Shabal192Hasher.hash((), &bytes).unwrap();
         }
     }
 }

--- a/src/shabal/shabal224.rs
+++ b/src/shabal/shabal224.rs
@@ -2,6 +2,7 @@
 use shabal::{Digest, Shabal224};
 
 // Internal imports
+use crate::error::HshResult;
 use crate::hasher::Hasher;
 use crate::types::HashOutput;
 
@@ -10,10 +11,10 @@ pub struct Shabal224Hasher;
 impl Hasher for Shabal224Hasher {
     type HashInput = ();
 
-    fn hash(&self, _input: (), bytes: &[u8]) -> HashOutput {
+    fn hash(&self, _input: (), bytes: &[u8]) -> HshResult<HashOutput> {
         let mut hasher = Shabal224::new();
         hasher.update(bytes);
-        HashOutput::new(hasher.finalize())
+        Ok(HashOutput::new(hasher.finalize()))
     }
 }
 
@@ -26,7 +27,7 @@ mod test {
     fn test_shabal224_hash_password() {
         let password = "password";
 
-        let hash = Shabal224Hasher.hash_str((), password);
+        let hash = Shabal224Hasher.hash_str((), password).unwrap();
 
         assert_eq!(
             "d2d9053f6c23d9d34e008f8f6b3fbf023370f05371315b406a45771f",
@@ -38,7 +39,7 @@ mod test {
     fn test_shabal224_hash_bytes() {
         let bytes = b"password";
 
-        let hash = Shabal224Hasher.hash((), bytes);
+        let hash = Shabal224Hasher.hash((), bytes).unwrap();
 
         assert_eq!(
             "d2d9053f6c23d9d34e008f8f6b3fbf023370f05371315b406a45771f",
@@ -57,6 +58,18 @@ mod test {
             bytes in proptest::collection::vec(any::<u8>(), 0..1000)
         ) {
             let _ = Shabal224Hasher.hash((), &bytes);
+        }
+
+        #[test]
+        fn fuzz_shabal224_hash_returns_ok(pass in ".*") {
+            Shabal224Hasher.hash_str((), &pass).unwrap();
+        }
+
+        #[test]
+        fn fuzz_shabal224_hash_bytes_returns_ok(
+            bytes in proptest::collection::vec(any::<u8>(), 0..1000)
+        ) {
+            Shabal224Hasher.hash((), &bytes).unwrap();
         }
     }
 }

--- a/src/shabal/shabal256.rs
+++ b/src/shabal/shabal256.rs
@@ -2,6 +2,7 @@
 use shabal::{Digest, Shabal256};
 
 // Internal imports
+use crate::error::HshResult;
 use crate::hasher::Hasher;
 use crate::types::HashOutput;
 
@@ -10,10 +11,10 @@ pub struct Shabal256Hasher;
 impl Hasher for Shabal256Hasher {
     type HashInput = ();
 
-    fn hash(&self, _input: (), bytes: &[u8]) -> HashOutput {
+    fn hash(&self, _input: (), bytes: &[u8]) -> HshResult<HashOutput> {
         let mut hasher = Shabal256::new();
         hasher.update(bytes);
-        HashOutput::new(hasher.finalize())
+        Ok(HashOutput::new(hasher.finalize()))
     }
 }
 
@@ -26,7 +27,7 @@ mod test {
     fn test_shabal256_hash_password() {
         let password = "password";
 
-        let hash = Shabal256Hasher.hash_str((), password);
+        let hash = Shabal256Hasher.hash_str((), password).unwrap();
 
         assert_eq!(
             "efb82bf2dc681f74951a61a8795606a47d1cdf573980d3cf65a3cb3371e8e7a8",
@@ -38,7 +39,7 @@ mod test {
     fn test_shabal256_hash_bytes() {
         let bytes = b"password";
 
-        let hash = Shabal256Hasher.hash((), bytes);
+        let hash = Shabal256Hasher.hash((), bytes).unwrap();
 
         assert_eq!(
             "efb82bf2dc681f74951a61a8795606a47d1cdf573980d3cf65a3cb3371e8e7a8",
@@ -57,6 +58,18 @@ mod test {
             bytes in proptest::collection::vec(any::<u8>(), 0..1000)
         ) {
             let _ = Shabal256Hasher.hash((), &bytes);
+        }
+
+        #[test]
+        fn fuzz_shabal256_hash_returns_ok(pass in ".*") {
+            Shabal256Hasher.hash_str((), &pass).unwrap();
+        }
+
+        #[test]
+        fn fuzz_shabal256_hash_bytes_returns_ok(
+            bytes in proptest::collection::vec(any::<u8>(), 0..1000)
+        ) {
+            Shabal256Hasher.hash((), &bytes).unwrap();
         }
     }
 }

--- a/src/streebog/streebog512.rs
+++ b/src/streebog/streebog512.rs
@@ -2,6 +2,7 @@
 use streebog::{Digest, Streebog512};
 
 // Internal imports
+use crate::error::HshResult;
 use crate::hasher::Hasher;
 use crate::types::HashOutput;
 
@@ -10,10 +11,10 @@ pub struct Streebog512Hasher;
 impl Hasher for Streebog512Hasher {
     type HashInput = ();
 
-    fn hash(&self, _input: (), bytes: &[u8]) -> HashOutput {
+    fn hash(&self, _input: (), bytes: &[u8]) -> HshResult<HashOutput> {
         let mut hasher = Streebog512::new();
         hasher.update(bytes);
-        HashOutput::new(hasher.finalize())
+        Ok(HashOutput::new(hasher.finalize()))
     }
 }
 
@@ -26,7 +27,7 @@ mod test {
     fn test_streebog512_hash_password() {
         let password = "password";
 
-        let hash = Streebog512Hasher.hash_str((), password);
+        let hash = Streebog512Hasher.hash_str((), password).unwrap();
 
         assert_eq!("1c0fe130cdde2e5018892d7749f859ab65858a19312174427576717694352734c53ba393b5ef475ee4c49f26ccd489b35cc4c72ce511b5a67e6f19e95d69db43", hash.as_hex());
     }
@@ -35,7 +36,7 @@ mod test {
     fn test_streebog512_hash_bytes() {
         let bytes = b"password";
 
-        let hash = Streebog512Hasher.hash((), bytes);
+        let hash = Streebog512Hasher.hash((), bytes).unwrap();
 
         assert_eq!("1c0fe130cdde2e5018892d7749f859ab65858a19312174427576717694352734c53ba393b5ef475ee4c49f26ccd489b35cc4c72ce511b5a67e6f19e95d69db43", hash.as_hex());
     }
@@ -51,6 +52,18 @@ mod test {
             bytes in proptest::collection::vec(any::<u8>(), 0..1000)
         ) {
             let _ = Streebog512Hasher.hash((), &bytes);
+        }
+
+        #[test]
+        fn fuzz_streebog512_hash_returns_ok(pass in ".*") {
+            Streebog512Hasher.hash_str((), &pass).unwrap();
+        }
+
+        #[test]
+        fn fuzz_streebog512_hash_bytes_returns_ok(
+            bytes in proptest::collection::vec(any::<u8>(), 0..1000)
+        ) {
+            Streebog512Hasher.hash((), &bytes).unwrap();
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -6,8 +6,8 @@ use std::str::FromStr;
 use b64::{CharacterSet, Config, Newline, ToBase64};
 
 // Internal imports
-use crate::format::get_format;
 use crate::error::{HshErr, HshResult};
+use crate::format::get_format;
 
 // Re-exports
 pub use crate::bcrypt::Salt;
@@ -156,7 +156,7 @@ impl HashOutput {
         match format {
             Format::Base64 => self.as_base64(),
             Format::Bytes => format!("{:?}", self.as_bytes()),
-            Format::Hex => self.as_hex()
+            Format::Hex => self.as_hex(),
         }
     }
 

--- a/src/whirlpool/mod.rs
+++ b/src/whirlpool/mod.rs
@@ -2,6 +2,7 @@
 use whirlpool::{Digest, Whirlpool};
 
 // Internal imports
+use crate::error::HshResult;
 use crate::hasher::Hasher;
 use crate::types::HashOutput;
 
@@ -10,10 +11,10 @@ pub struct WhirlpoolHasher;
 impl Hasher for WhirlpoolHasher {
     type HashInput = ();
 
-    fn hash(&self, _input: (), bytes: &[u8]) -> HashOutput {
+    fn hash(&self, _input: (), bytes: &[u8]) -> HshResult<HashOutput> {
         let mut hasher = Whirlpool::new();
         hasher.update(bytes);
-        HashOutput::new(hasher.finalize())
+        Ok(HashOutput::new(hasher.finalize()))
     }
 }
 
@@ -26,7 +27,7 @@ mod test {
     fn test_whirlpool_hash_password() {
         let password = "password";
 
-        let hash = WhirlpoolHasher.hash_str((), password);
+        let hash = WhirlpoolHasher.hash_str((), password).unwrap();
 
         assert_eq!("74dfc2b27acfa364da55f93a5caee29ccad3557247eda238831b3e9bd931b01d77fe994e4f12b9d4cfa92a124461d2065197d8cf7f33fc88566da2db2a4d6eae", hash.as_hex());
     }
@@ -35,7 +36,7 @@ mod test {
     fn test_whirlpool_hash_bytes() {
         let bytes = b"password";
 
-        let hash = WhirlpoolHasher.hash((), bytes);
+        let hash = WhirlpoolHasher.hash((), bytes).unwrap();
 
         assert_eq!("74dfc2b27acfa364da55f93a5caee29ccad3557247eda238831b3e9bd931b01d77fe994e4f12b9d4cfa92a124461d2065197d8cf7f33fc88566da2db2a4d6eae", hash.as_hex());
     }
@@ -51,6 +52,18 @@ mod test {
             bytes in proptest::collection::vec(any::<u8>(), 0..1000)
         ) {
             let _ = WhirlpoolHasher.hash((), &bytes);
+        }
+
+        #[test]
+        fn fuzz_whirlpool_hash_returns_ok(pass in ".*") {
+            WhirlpoolHasher.hash_str((), &pass).unwrap();
+        }
+
+        #[test]
+        fn fuzz_whirlpool_hash_bytes_returns_ok(
+            bytes in proptest::collection::vec(any::<u8>(), 0..1000)
+        ) {
+            WhirlpoolHasher.hash((), &bytes).unwrap();
         }
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -99,7 +99,7 @@ fn missing_bcrypt_salt() -> Result<(), Box<dyn Error>> {
 fn bcrypt_invalid_salt_hex_odd_digits() -> Result<(), Box<dyn Error>> {
     let cmd = setup(vec!["Hello, world!", "bcrypt", "-c", "1", "-s", "1a54e"])?;
 
-    assert_errors(cmd, vec!["invalid salt hex -- Odd number of digits"]);
+    assert_errors(cmd, vec!["hex must be of even digits"]);
 
     Ok(())
 }
@@ -117,7 +117,7 @@ fn bcrypt_invalid_salt_incorrect_length_short() -> Result<(), Box<dyn Error>> {
 
     assert_errors(
         cmd,
-        vec!["invalid salt -- incorrect salt length (should be 16 bytes, found 6)"],
+        vec!["incorrect salt length (should be 16 bytes, found 6)"],
     );
 
     Ok(())
@@ -136,7 +136,7 @@ fn bcrypt_invalid_salt_incorrect_length_long() -> Result<(), Box<dyn Error>> {
 
     assert_errors(
         cmd,
-        vec!["invalid salt -- incorrect salt length (should be 16 bytes, found 22)"],
+        vec!["incorrect salt length (should be 16 bytes, found 22)"],
     );
 
     Ok(())


### PR DESCRIPTION
* Add `format` argument to control output format and `salt_format` argument to control expected format of salt input

* Improve error handling

* Update tests, format code