### PR TITLE
Rework error handling, removing unnecessary error variants and adding convenience methods

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -59,6 +59,27 @@ mod test {
     use super::*;
 
     #[test]
+    fn test_hsh_err_exit_code_incorrect_salt_length() {
+        let err = HshErr::IncorrectSaltLength("should be 16 bytes, found 22".to_string());
+        let code = err.exitcode();
+        assert_eq!(65i32, code);
+    }
+
+    #[test]
+    fn test_hsh_err_exit_code_salt_from_str_error() {
+        let err = HshErr::SaltFromStrError("salt cannot be blank".to_string());
+        let code = err.exitcode();
+        assert_eq!(65i32, code);
+    }
+
+    #[test]
+    fn test_hsh_err_exit_code_unsuported_str_length() {
+        let err = HshErr::UnsuportedStrLength("".to_string());
+        let code = err.exitcode();
+        assert_eq!(65i32, code);
+    }
+
+    #[test]
     fn test_hsh_err_display_incorrect_salt_length() {
         let err = HshErr::IncorrectSaltLength("should be 16 bytes, found 22".to_string());
         let msg = format!("{}", err);

--- a/src/error.rs
+++ b/src/error.rs
@@ -99,4 +99,10 @@ mod test {
         let msg = format!("{}", err);
         assert_eq!("unsuported string length ()", &msg);
     }
+
+    #[test]
+    fn test_hsh_result_unwrap_or_exit_ok() {
+        let res: HshResult<&'static str> = Ok("Hello, world!");
+        assert_eq!("Hello, world!", res.unwrap_or_exit());
+    }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,7 +6,6 @@ use std::fmt::{self, Debug, Display};
 #[derive(Debug, PartialEq)]
 pub enum HshErr {
     IncorrectSaltLength(String),
-    InvalidHashFunction(String),
     SaltFromStrError(String),
     UnsuportedStrLength(String),
 }
@@ -16,9 +15,6 @@ impl Display for HshErr {
         match self {
             HshErr::IncorrectSaltLength(msg) => {
                 f.write_str(&format!("incorrect salt length ({})", msg))
-            }
-            HshErr::InvalidHashFunction(func) => {
-                f.write_str(&format!("invalid hash function '{}'", func))
             }
             HshErr::SaltFromStrError(msg) => f.write_str(&format!("error parsing salt: {}", msg)),
             HshErr::UnsuportedStrLength(msg) => {
@@ -41,13 +37,6 @@ mod test {
         let err = HshErr::IncorrectSaltLength("should be 16 bytes, found 22".to_string());
         let msg = format!("{}", err);
         assert_eq!("incorrect salt length (should be 16 bytes, found 22)", &msg);
-    }
-
-    #[test]
-    fn test_hsh_err_display_invalid_hash_function() {
-        let err = HshErr::InvalidHashFunction("foobar".to_string());
-        let msg = format!("{}", err);
-        assert_eq!("invalid hash function 'foobar'", &msg);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 use structopt::StructOpt;
 
 // Lib imports
-use hsh::error::HshResult;
+use hsh::error::{HshResult, UnwrapOrExit};
 use hsh::format::FORMAT_MODE;
 use hsh::hash;
 use hsh::types::{Format, HashFunction, Salt};
@@ -34,16 +34,9 @@ struct Opt {
 
 fn main() {
     let opt = setup();
-    let salt = parse_salt(&opt).unwrap_or_else(|err| {
-        eprintln!("{}", err);
-        std::process::exit(exitcode::DATAERR);
-    });
-    let hash_res = hash(&opt.string, opt.function, opt.cost, salt);
-    if hash_res.is_err() {
-        eprintln!("{}", hash_res.unwrap_err());
-        std::process::exit(exitcode::DATAERR);
-    }
-    println!("{}", hash_res.unwrap());
+    let salt = parse_salt(&opt).unwrap_or_exit();
+    let hash = hash(&opt.string, opt.function, opt.cost, salt).unwrap_or_exit();
+    println!("{}", hash);
     std::process::exit(exitcode::OK);
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -135,7 +135,8 @@ impl FromStr for HashFunction {
             "streebog256" => Ok(Streebog256),
             "streebog512" => Ok(Streebog512),
             "whirlpool" => Ok(Whirlpool),
-            str => Err(HshErr::InvalidHashFunction(String::from(str))),
+            // StructOpt ensures that the input string is among those returned by `Self::variants()` before it is parsed, so we should never reach this point
+            _ => panic!("invalid hash function"),
         }
     }
 }
@@ -206,7 +207,8 @@ impl FromStr for Format {
             "base64" => Ok(Format::Base64),
             "bytes" => Ok(Format::Bytes),
             "hex" => Ok(Format::Hex),
-            _ => panic!(),
+            // StructOpt ensures that the input string is among those returned by `Self::variants()` before it is parsed, so we should never reach this point
+            _ => panic!("invalid format"),
         }
     }
 }
@@ -224,15 +226,15 @@ mod test {
     }
 
     #[test]
+    #[should_panic(expected = "invalid hash function")]
     fn test_hash_function_from_empty_str() {
-        let err = HashFunction::from_str("").unwrap_err();
-        assert_eq!(HshErr::InvalidHashFunction(String::from("")), err);
+        let _ = HashFunction::from_str("");
     }
 
     #[test]
+    #[should_panic(expected = "invalid hash function")]
     fn test_hash_function_from_str_invalid() {
-        let err = HashFunction::from_str("foobar").unwrap_err();
-        assert_eq!(HshErr::InvalidHashFunction(String::from("foobar")), err);
+        let _ = HashFunction::from_str("foobar");
     }
 
     #[test]
@@ -386,12 +388,19 @@ mod test {
         assert_eq!(Format::Base64, format.unwrap());
     }
 
-    proptest! {
-        #[test]
-        fn fuzz_hash_function_from_str_does_not_panic(str in ".*") {
-            let _ = HashFunction::from_str(&str);
-        }
+    #[test]
+    #[should_panic(expected = "invalid format")]
+    fn test_format_from_empty_str() {
+        let _ = Format::from_str("");
+    }
 
+    #[test]
+    #[should_panic(expected = "invalid format")]
+    fn test_format_from_str_invalid() {
+        let _ = Format::from_str("foobar");
+    }
+
+    proptest! {
         #[test]
         fn fuzz_hash_output_new_does_not_panic(
             bytes in proptest::collection::vec(any::<u8>(), 0..1000)


### PR DESCRIPTION
- Remove unnecessary error variant `InvalidHashFunction`

 Since `StructOpt` automatically checks that the input string for 
`function` is among the valid options before parsing it, we don't need a 
seperate error for the case where `from_str` encounters an invalid 
string. If this occurs, it is a bug. Thus, simply panic in this case.

Additionally, update tests for `HashFunction::from_str` to test new 
behaviour.

- Add `unwrap_or_exit()` function to HshResult for easier error handling

Add `unwrap_or_exit()` function to HshResult type for easier and cleaner 
error handling, along with `exitcode()` function of HshErr.

Ideally, `unwrap_or_exit()` would be implemented directly on HshResult, 
but, in order to get around the orphan rules, it must be part of a 
locally-defined trait implemented on HshResult.