### PR TITLE
Extract all error variants arising from string to salt conversion into separate error enum

### DIFF
--- a/proptest-regressions/bcrypt.txt
+++ b/proptest-regressions/bcrypt.txt
@@ -4,5 +4,4 @@
 #
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
-cc 5b7a5cb0bc9dab4c7e78ca879e72e7c4ec3f40c248584545310e7fb8b79bfe94 # shrinks to s = ""
-cc 01fe11aaf898432dc357be3b6e358b94bc876ef40de4390352001a8b3ff73202 # shrinks to str = " a A 0A a \u{0}\u{0}\u{b}\u{0} ࠀ"
+cc 8a966007c8dfcd71d89e76dab79283e82d8a69961012a0d26cba5e5cf4bb10a6 # shrinks to base64 = ":!$:"

--- a/src/bcrypt.rs
+++ b/src/bcrypt.rs
@@ -7,7 +7,7 @@ use lazy_static::lazy_static;
 use regex::Regex;
 
 // Internal imports
-use crate::error::{HshErr, HshResult};
+use crate::error::{HshErr, HshResult, SaltFromStrError};
 use crate::format::get_salt_format;
 use crate::hasher::Hasher;
 use crate::types::{Format, HashOutput};
@@ -20,12 +20,9 @@ impl Salt {
         Self(data)
     }
 
-    pub fn from_vec(data: Vec<u8>) -> HshResult<Self> {
+    pub fn from_vec(data: Vec<u8>) -> Result<Self, SaltFromStrError> {
         if data.len() != 16 {
-            return Err(HshErr::IncorrectSaltLength(format!(
-                "should be 16 bytes, found {}",
-                data.len()
-            )));
+            return Err(SaltFromStrError::IncorrectLength(16, data.len()));
         }
 
         let mut arr = [0u8; 16];
@@ -37,27 +34,21 @@ impl Salt {
         Ok(Self::new(arr))
     }
 
-    pub fn from_bytes(str: &str) -> HshResult<Self> {
-        let len = str.len();
+    pub fn from_bytes(str: &str) -> Result<Self, SaltFromStrError> {
+        let str = str
+            .strip_prefix('[')
+            .and_then(|s| s.strip_suffix(']'))
+            .ok_or(SaltFromStrError::InvalidByteFormat)?;
 
-        if !(str.starts_with('[') && str.ends_with(']')) {
-            return Err(HshErr::SaltFromStrError(String::from(
-                "invalid format for salt byte input",
-            )));
-        }
+        let strs = str.split(',');
+        let mut bytes = Vec::with_capacity(16);
 
-        let strs: Vec<&str> = str[1..len - 1].split(',').collect();
-        let mut bytes = Vec::with_capacity(str.len());
-
-        for s in strs {
+        for (i, s) in strs.enumerate() {
             let s = s.trim();
             let res = u8::from_str(s);
 
             if res.is_err() {
-                return Err(HshErr::SaltFromStrError(format!(
-                    "invalid string '{}' in byte input",
-                    s
-                )));
+                return Err(SaltFromStrError::InvalidByte(s.to_string(), i));
             }
 
             bytes.push(res.unwrap());
@@ -66,46 +57,42 @@ impl Salt {
         Self::from_vec(bytes)
     }
 
-    pub fn from_hex(str: &str) -> HshResult<Self> {
+    pub fn from_hex(str: &str) -> Result<Self, SaltFromStrError> {
         lazy_static! {
             static ref REGEX: Regex = Regex::new(r"([^0-9a-fA-F])").unwrap();
         }
 
         if str.len() % 2 != 0 {
-            return Err(HshErr::SaltFromStrError(String::from(
-                "hex must be of even digits",
-            )));
+            return Err(SaltFromStrError::InvalidHexLength);
         }
 
         let illegal_char = REGEX.find(str);
-        if illegal_char.is_some() {
-            return Err(HshErr::SaltFromStrError(format!(
-                "hex contains illegal character '{}'",
-                illegal_char.unwrap().as_str()
-            )));
+        if let Some(char) = illegal_char {
+            let start = char.start();
+            let char = char.as_str().chars().next().unwrap();
+
+            return Err(SaltFromStrError::InvalidHexCharacter(char, start));
         }
 
         let decoded = hex::decode(str).unwrap();
         Self::from_vec(decoded)
     }
 
-    pub fn from_base64(str: &str) -> HshResult<Self> {
+    pub fn from_base64(str: &str) -> Result<Self, SaltFromStrError> {
         lazy_static! {
             static ref REGEX: Regex = Regex::new(r"([^0-9a-zA-Z/\+=])").unwrap();
         }
 
         if str.len() % 4 != 0 {
-            return Err(HshErr::SaltFromStrError(String::from(
-                "length of base64 string must be a multiple of four",
-            )));
+            return Err(SaltFromStrError::InvalidBase64Length);
         }
 
         let illegal_char = REGEX.find(str);
-        if illegal_char.is_some() {
-            return Err(HshErr::SaltFromStrError(format!(
-                "base64 string contains illegal character '{}'",
-                illegal_char.unwrap().as_str()
-            )));
+        if let Some(char) = illegal_char {
+            let start = char.start();
+            let char = char.as_str().chars().next().unwrap();
+
+            return Err(SaltFromStrError::InvalidBase64Character(char, start));
         }
 
         let decoded = str.from_base64().unwrap();
@@ -118,15 +105,13 @@ impl FromStr for Salt {
 
     fn from_str(str: &str) -> HshResult<Salt> {
         if str.is_empty() {
-            return Err(HshErr::SaltFromStrError(String::from(
-                "salt cannot be blank",
-            )));
+            return Err(HshErr::SaltFromStrError(SaltFromStrError::BlankStr));
         }
 
         match get_salt_format() {
-            Format::Base64 => Salt::from_base64(str),
-            Format::Bytes => Salt::from_bytes(str),
-            Format::Hex => Salt::from_hex(str),
+            Format::Base64 => Ok(Salt::from_base64(str)?),
+            Format::Bytes => Ok(Salt::from_bytes(str)?),
+            Format::Hex => Ok(Salt::from_hex(str)?),
         }
     }
 }
@@ -194,10 +179,7 @@ mod test {
 
         let err = Salt::from_vec(bytes).unwrap_err();
 
-        assert_eq!(
-            HshErr::IncorrectSaltLength(String::from("should be 16 bytes, found 0")),
-            err,
-        )
+        assert_eq!(SaltFromStrError::IncorrectLength(16, 0), err,);
     }
 
     #[test]
@@ -208,10 +190,7 @@ mod test {
 
         let err = Salt::from_vec(bytes).unwrap_err();
 
-        assert_eq!(
-            HshErr::IncorrectSaltLength(String::from("should be 16 bytes, found 22")),
-            err,
-        );
+        assert_eq!(SaltFromStrError::IncorrectLength(16, 22), err,);
     }
 
     #[test]
@@ -229,10 +208,7 @@ mod test {
 
         let err = Salt::from_bytes(&bytes).unwrap_err();
 
-        assert_eq!(
-            HshErr::SaltFromStrError(String::from("invalid format for salt byte input")),
-            err,
-        )
+        assert_eq!(SaltFromStrError::InvalidByteFormat, err,);
     }
 
     #[test]
@@ -242,7 +218,7 @@ mod test {
         let err = Salt::from_bytes(&bytes).unwrap_err();
 
         assert_eq!(
-            HshErr::SaltFromStrError(String::from("invalid string 'nineteen' in byte input")),
+            SaltFromStrError::InvalidByte(String::from("nineteen"), 7),
             err
         );
     }
@@ -254,10 +230,7 @@ mod test {
 
         let err = Salt::from_bytes(&bytes).unwrap_err();
 
-        assert_eq!(
-            HshErr::IncorrectSaltLength(String::from("should be 16 bytes, found 22")),
-            err,
-        );
+        assert_eq!(SaltFromStrError::IncorrectLength(16, 22), err,);
     }
 
     #[test]
@@ -276,10 +249,7 @@ mod test {
 
         let err = Salt::from_hex(&hex).unwrap_err();
 
-        assert_eq!(
-            HshErr::IncorrectSaltLength(String::from("should be 16 bytes, found 0")),
-            err,
-        )
+        assert_eq!(SaltFromStrError::IncorrectLength(16, 0), err,);
     }
 
     #[test]
@@ -288,10 +258,7 @@ mod test {
 
         let err = Salt::from_hex(&hex).unwrap_err();
 
-        assert_eq!(
-            HshErr::SaltFromStrError(String::from("hex must be of even digits")),
-            err
-        );
+        assert_eq!(SaltFromStrError::InvalidHexLength, err);
     }
 
     #[test]
@@ -300,10 +267,7 @@ mod test {
 
         let err = Salt::from_hex(&hex).unwrap_err();
 
-        assert_eq!(
-            HshErr::SaltFromStrError(String::from("hex contains illegal character 'n'")),
-            err
-        );
+        assert_eq!(SaltFromStrError::InvalidHexCharacter('n', 1), err);
     }
 
     #[test]
@@ -315,10 +279,7 @@ mod test {
 
         let err = Salt::from_hex(&hex).unwrap_err();
 
-        assert_eq!(
-            HshErr::IncorrectSaltLength(String::from("should be 16 bytes, found 22")),
-            err,
-        );
+        assert_eq!(SaltFromStrError::IncorrectLength(16, 22), err,);
     }
 
     #[test]
@@ -342,10 +303,7 @@ mod test {
 
         let err = Salt::from_base64(&base64).unwrap_err();
 
-        assert_eq!(
-            HshErr::IncorrectSaltLength(String::from("should be 16 bytes, found 0")),
-            err,
-        )
+        assert_eq!(SaltFromStrError::IncorrectLength(16, 0), err,);
     }
 
     #[test]
@@ -354,12 +312,7 @@ mod test {
 
         let err = Salt::from_base64(&base64).unwrap_err();
 
-        assert_eq!(
-            HshErr::SaltFromStrError(String::from(
-                "length of base64 string must be a multiple of four"
-            )),
-            err
-        );
+        assert_eq!(SaltFromStrError::InvalidBase64Length, err);
     }
 
     #[test]
@@ -368,10 +321,7 @@ mod test {
 
         let err = Salt::from_base64(&base64).unwrap_err();
 
-        assert_eq!(
-            HshErr::SaltFromStrError(String::from("base64 string contains illegal character '$'")),
-            err
-        );
+        assert_eq!(SaltFromStrError::InvalidBase64Character('$', 7), err);
     }
 
     #[test]
@@ -388,10 +338,7 @@ mod test {
 
         let err = Salt::from_base64(&base64).unwrap_err();
 
-        assert_eq!(
-            HshErr::IncorrectSaltLength(String::from("should be 16 bytes, found 22")),
-            err,
-        );
+        assert_eq!(SaltFromStrError::IncorrectLength(16, 22), err,);
     }
 
     #[test]
@@ -412,10 +359,7 @@ mod test {
 
             let err = Salt::from_str(&bytes).unwrap_err();
 
-            assert_eq!(
-                HshErr::SaltFromStrError(String::from("salt cannot be blank")),
-                err,
-            )
+            assert_eq!(HshErr::SaltFromStrError(SaltFromStrError::BlankStr), err);
         });
     }
 
@@ -427,7 +371,10 @@ mod test {
             let err = Salt::from_str(&bytes).unwrap_err();
 
             assert_eq!(
-                HshErr::SaltFromStrError(String::from("invalid string 'nineteen' in byte input")),
+                HshErr::SaltFromStrError(SaltFromStrError::InvalidByte(
+                    String::from("nineteen"),
+                    7
+                )),
                 err
             );
         });
@@ -442,7 +389,7 @@ mod test {
             let err = Salt::from_str(&bytes).unwrap_err();
 
             assert_eq!(
-                HshErr::IncorrectSaltLength(String::from("should be 16 bytes, found 22")),
+                HshErr::SaltFromStrError(SaltFromStrError::IncorrectLength(16, 22)),
                 err,
             );
         })
@@ -467,10 +414,7 @@ mod test {
 
             let err = Salt::from_str(&hex).unwrap_err();
 
-            assert_eq!(
-                HshErr::SaltFromStrError(String::from("salt cannot be blank")),
-                err,
-            )
+            assert_eq!(HshErr::SaltFromStrError(SaltFromStrError::BlankStr), err);
         });
     }
 
@@ -482,7 +426,7 @@ mod test {
             let err = Salt::from_str(&hex).unwrap_err();
 
             assert_eq!(
-                HshErr::SaltFromStrError(String::from("hex must be of even digits")),
+                HshErr::SaltFromStrError(SaltFromStrError::InvalidHexLength),
                 err
             );
         });
@@ -496,7 +440,7 @@ mod test {
             let err = Salt::from_str(&hex).unwrap_err();
 
             assert_eq!(
-                HshErr::SaltFromStrError(String::from("hex contains illegal character 'n'")),
+                HshErr::SaltFromStrError(SaltFromStrError::InvalidHexCharacter('n', 1)),
                 err
             );
         });
@@ -513,7 +457,7 @@ mod test {
             let err = Salt::from_str(&hex).unwrap_err();
 
             assert_eq!(
-                HshErr::IncorrectSaltLength(String::from("should be 16 bytes, found 22")),
+                HshErr::SaltFromStrError(SaltFromStrError::IncorrectLength(16, 22)),
                 err,
             );
         });
@@ -543,10 +487,7 @@ mod test {
 
             let err = Salt::from_str(&base64).unwrap_err();
 
-            assert_eq!(
-                HshErr::SaltFromStrError(String::from("salt cannot be blank")),
-                err,
-            );
+            assert_eq!(HshErr::SaltFromStrError(SaltFromStrError::BlankStr), err);
         });
     }
 
@@ -558,9 +499,7 @@ mod test {
             let err = Salt::from_str(&base64).unwrap_err();
 
             assert_eq!(
-                HshErr::SaltFromStrError(String::from(
-                    "length of base64 string must be a multiple of four"
-                )),
+                HshErr::SaltFromStrError(SaltFromStrError::InvalidBase64Length),
                 err
             );
         });
@@ -575,9 +514,7 @@ mod test {
             let err = Salt::from_str(&base64).unwrap_err();
 
             assert_eq!(
-                HshErr::SaltFromStrError(String::from(
-                    "base64 string contains illegal character ';'"
-                )),
+                HshErr::SaltFromStrError(SaltFromStrError::InvalidBase64Character(';', 8)),
                 err
             );
         });
@@ -599,7 +536,7 @@ mod test {
             let err = Salt::from_str(&base64).unwrap_err();
 
             assert_eq!(
-                HshErr::IncorrectSaltLength(String::from("should be 16 bytes, found 22")),
+                HshErr::SaltFromStrError(SaltFromStrError::IncorrectLength(16, 22)),
                 err,
             );
         });
@@ -709,12 +646,9 @@ mod test {
                 assert_eq!(vec, res.unwrap().0.to_vec());
             } else {
                 assert_eq!(
-                    HshErr::IncorrectSaltLength(format!(
-                        "should be 16 bytes, found {}",
-                        len
-                    )),
+                    SaltFromStrError::IncorrectLength(16, len),
                     res.unwrap_err(),
-                )
+                );
             }
         }
 
@@ -752,14 +686,13 @@ mod test {
         fn fuzz_salt_from_bytes_invalid_digits(input in "([a-zA-Z]+,)+") {
             let err = Salt::from_bytes(&format!("[{}]", input)).unwrap_err();
             let msg = format!("{}", err);
-            assert!(msg.contains("error parsing salt: invalid string"));
-            assert!(msg.contains("in byte input"));
+            assert!(msg.contains("byte input contains invalid byte"));
         }
 
         #[test]
         fn fuzz_salt_from_bytes_invalid_format(input in "[0-9a-zA-Z]*") {
             let err = Salt::from_bytes(&input).unwrap_err();
-            assert_eq!(HshErr::SaltFromStrError(String::from("invalid format for salt byte input")), err);
+            assert_eq!(SaltFromStrError::InvalidByteFormat, err);
         }
 
         #[test]
@@ -772,14 +705,14 @@ mod test {
         #[test]
         fn fuzz_salt_from_hex_odd_length(hex in "[0-9a-f]([0-9a-f][0-9a-f])*") {
             let err = Salt::from_hex(&hex).unwrap_err();
-            assert_eq!(HshErr::SaltFromStrError(String::from("hex must be of even digits")), err);
+            assert_eq!(SaltFromStrError::InvalidHexLength, err);
         }
 
         #[test]
         fn fuzz_salt_from_hex_invalid_characters(hex in "([g-zG-Z][g-zG-Z])+") {
             let err = Salt::from_hex(&hex).unwrap_err();
             let msg = format!("{}", err);
-            assert!(msg.contains("hex contains illegal character"));
+            assert!(msg.contains("invalid character") && msg.contains("in hex at index"));
         }
 
         #[test]
@@ -797,14 +730,14 @@ mod test {
         #[test]
         fn fuzz_salt_from_base64_invalid_length(base64 in "[0-9a-zA-Z/+=]{1,3}([0-9a-zA-Z/+=]{4})*") {
             let err = Salt::from_base64(&base64).unwrap_err();
-            assert_eq!(HshErr::SaltFromStrError(String::from("length of base64 string must be a multiple of four")), err);
+            assert_eq!(SaltFromStrError::InvalidBase64Length, err);
         }
 
         #[test]
         fn fuzz_salt_from_base64_invalid_characters(base64 in "[!\"$%&'*,-.:;<=>?@]{4}") {
             let err = Salt::from_base64(&base64).unwrap_err();
             let msg = format!("{}", err);
-            assert!(msg.contains("base64 string contains illegal character"), msg);
+            assert!(msg.contains("invalid character") && msg.contains("in base64 string at index"));
         }
 
         #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -60,11 +60,11 @@ impl Display for SaltFromStrError {
         match self {
             Self::BlankStr => f.write_str("salt cannot be blank"),
             Self::IncorrectLength(exp, act) => f.write_fmt(format_args!("incorrect salt length (expected {} bytes, found {})", exp, act)),
-            Self::InvalidBase64Character(c, i) => f.write_fmt(format_args!("invalid character {} in base64 string at index {}", c, i)),
+            Self::InvalidBase64Character(c, i) => f.write_fmt(format_args!("invalid character '{}' in base64 string at index {}", c, i)),
             Self::InvalidBase64Length => f.write_str("length of base64 string must be divisible by 4"),
-            Self::InvalidByte(b, i) => f.write_fmt(format_args!("byte input contains invalid byte {} at array index {}", b, i)),
+            Self::InvalidByte(b, i) => f.write_fmt(format_args!("byte input contains invalid byte '{}' at array index {}", b, i)),
             Self::InvalidByteFormat => f.write_str("byte input was incorrectly formatted (string should begin and end with '[' and ']' and contain a comma-separated list of values)"),
-            Self::InvalidHexCharacter(c, i) => f.write_fmt(format_args!("invalid character {} in hex at index {}", c, i)),
+            Self::InvalidHexCharacter(c, i) => f.write_fmt(format_args!("invalid character '{}' in hex at index {}", c, i)),
             Self::InvalidHexLength => f.write_fmt(format_args!("hex must have even length")),
         }
     }
@@ -111,7 +111,7 @@ mod test {
     fn hsh_err_exit_code_salt_from_str_error() {
         let err = HshErr::SaltFromStrError(SaltFromStrError::BlankStr);
         let code = err.exitcode();
-        assert_eq!(65i64, code);
+        assert_eq!(65i32, code);
     }
 
     #[test]
@@ -120,13 +120,13 @@ mod test {
             "input string for bcrypt hash function must be between 0 and 72 bytes",
         ));
         let code = err.exitcode();
-        assert_eq!(65i64, code);
+        assert_eq!(65i32, code);
     }
 
     #[test]
     fn hsh_err_from_salt_from_str_error() {
         let err = HshErr::from(SaltFromStrError::BlankStr);
-        assert_eq!(HshErr::SaltFromStrError(SaltFromStrError::BlankStr));
+        assert_eq!(HshErr::SaltFromStrError(SaltFromStrError::BlankStr), err);
     }
 
     #[test]
@@ -159,10 +159,10 @@ mod test {
 
     #[test]
     fn salt_from_str_error_display_invalid_byte() {
-        let err = SaltFromStrError::InvalidByte("-1", 2);
+        let err = SaltFromStrError::InvalidByte(String::from("-1"), 2);
         let msg = format!("{}", err);
         assert_eq!(
-            "byte input contains invalid byte \"-1\" at array index 2",
+            "byte input contains invalid byte '-1' at array index 2",
             &msg
         );
     }
@@ -178,14 +178,14 @@ mod test {
     fn salt_from_str_error_display_invalid_hex_character() {
         let err = SaltFromStrError::InvalidHexCharacter('~', 4);
         let msg = format!("{}", err);
-        assert_eq!("invalid character '~' in hex string at index 4", &msg);
+        assert_eq!("invalid character '~' in hex at index 4", &msg);
     }
 
     #[test]
     fn salt_from_str_error_display_invalid_hex_length() {
         let err = SaltFromStrError::InvalidHexLength;
         let msg = format!("{}", err);
-        assert_eq!("hex must be of even length", &msg);
+        assert_eq!("hex must have even length", &msg);
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -86,3 +86,104 @@ impl<T> UnwrapOrExit<T> for HshResult<T> {
 pub trait UnwrapOrExit<T> {
     fn unwrap_or_exit(self) -> T;
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn hsh_err_display_salt_from_str_error() {
+        let err = HshErr::SaltFromStrError(SaltFromStrError::BlankStr);
+        let msg = format!("{}", err);
+        assert_eq!("error parsing salt: salt cannot be blank", &msg);
+    }
+
+    #[test]
+    fn hsh_err_display_unsuported_str_length() {
+        let err = HshErr::UnsuportedStrLength(String::from("input string for bcrypt hash function must be between 0 and 72 bytes"));
+        let msg = format!("{}", err);
+        assert_eq!("unsuported string length: input string for bcrypt hash function must be between 0 and 72 bytes", &msg);
+    }
+
+    #[test]
+    fn hsh_err_exit_code_salt_from_str_error() {
+        let err = HshErr::SaltFromStrError(SaltFromStrError::BlankStr);
+        let code = err.exitcode();
+        assert_eq!(65i64, code);
+    }
+
+    #[test]
+    fn hsh_err_exit_code_unsuported_str_length() {
+        let err = HshErr::UnsuportedStrLength(String::from("input string for bcrypt hash function must be between 0 and 72 bytes"));
+        let code = err.exitcode();
+        assert_eq!(65i64, code);
+    }
+
+    #[test]
+    fn hsh_err_from_salt_from_str_error() {
+        let err = HshErr::from(SaltFromStrError::BlankStr);
+        assert_eq!(HshErr::SaltFromStrError(SaltFromStrError::BlankStr));
+    }
+
+    #[test]
+    fn salt_from_str_error_display_blank_str() {
+        let err = SaltFromStrError::BlankStr;
+        let msg = format!("{}", err);
+        assert_eq!("salt cannot be blank", &msg);
+    }
+
+    #[test]
+    fn salt_from_str_error_display_incorrect_length() {
+        let err = SaltFromStrError::IncorrectLength(16, 12);
+        let msg = format!("{}", err);
+        assert_eq!("incorrect salt length (expected 16 bytes, found 12)", &msg);
+    }
+
+    #[test]
+    fn salt_from_str_error_display_invalid_base64_character() {
+        let err = SaltFromStrError::InvalidBase64Character('~', 4);
+        let msg = format!("{}", err);
+        assert_eq!("invalid character '~' in base64 string at index 4", &msg);
+    }
+
+    #[test]
+    fn salt_from_str_error_display_invalid_base64_length() {
+        let err = SaltFromStrError::InvalidBase64Length;
+        let msg = format!("{}", err);
+        assert_eq!("length of base64 string must be divisible by 4", &msg);
+    }
+
+    #[test]
+    fn salt_from_str_error_display_invalid_byte() {
+        let err = SaltFromStrError::InvalidByte("-1", 2);
+        let msg = format!("{}", err);
+        assert_eq!("byte input contains invalid byte \"-1\" at array index 2", &msg);
+    }
+
+    #[test]
+    fn salt_from_str_error_display_invalid_byte_format() {
+        let err = SaltFromStrError::InvalidByteFormat;
+        let msg = format!("{}", err);
+        assert_eq!("byte input was incorrectly formatted (string should begin and end with '[' and ']' and contain a comma-separated list of values)", &msg);
+    }
+
+    #[test]
+    fn salt_from_str_error_display_invalid_hex_character() {
+        let err = SaltFromStrError::InvalidHexCharacter('~', 4);
+        let msg = format!("{}", err);
+        assert_eq!("invalid character '~' in hex string at index 4", &msg);
+    }
+
+    #[test]
+    fn salt_from_str_error_display_invalid_hex_length() {
+        let err = SaltFromStrError::InvalidHexLength;
+        let msg = format!("{}", err);
+        assert_eq!("hex must be of even length", &msg);
+    }
+
+    #[test]
+    fn test_hsh_result_unwrap_or_exit_ok() {
+        let res: HshResult<i64> = Ok(100);
+        assert_eq!(100, res.unwrap_or_exit());
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -100,7 +100,9 @@ mod test {
 
     #[test]
     fn hsh_err_display_unsuported_str_length() {
-        let err = HshErr::UnsuportedStrLength(String::from("input string for bcrypt hash function must be between 0 and 72 bytes"));
+        let err = HshErr::UnsuportedStrLength(String::from(
+            "input string for bcrypt hash function must be between 0 and 72 bytes",
+        ));
         let msg = format!("{}", err);
         assert_eq!("unsuported string length: input string for bcrypt hash function must be between 0 and 72 bytes", &msg);
     }
@@ -114,7 +116,9 @@ mod test {
 
     #[test]
     fn hsh_err_exit_code_unsuported_str_length() {
-        let err = HshErr::UnsuportedStrLength(String::from("input string for bcrypt hash function must be between 0 and 72 bytes"));
+        let err = HshErr::UnsuportedStrLength(String::from(
+            "input string for bcrypt hash function must be between 0 and 72 bytes",
+        ));
         let code = err.exitcode();
         assert_eq!(65i64, code);
     }
@@ -157,7 +161,10 @@ mod test {
     fn salt_from_str_error_display_invalid_byte() {
         let err = SaltFromStrError::InvalidByte("-1", 2);
         let msg = format!("{}", err);
-        assert_eq!("byte input contains invalid byte \"-1\" at array index 2", &msg);
+        assert_eq!(
+            "byte input contains invalid byte \"-1\" at array index 2",
+            &msg
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,10 +57,6 @@ struct Opt {
 
 fn main() {
     let opt = setup();
-    log::warn!("warning message");
-    log::info!("info message");
-    log::debug!("debug message");
-    log::trace!("trace message");
     let salt = parse_salt(&opt).unwrap_or_exit();
     let hash = hash(&opt.string, opt.function, opt.cost, salt).unwrap_or_exit();
     println!("{}", hash);
@@ -80,8 +76,6 @@ fn setup_logger(log_level: LevelFilter, colour: bool) -> Result<(), fern::InitEr
         .warn(Color::Yellow)
         .info(Color::Blue)
         .trace(Color::BrightBlack);
-
-    println!("{}", atty::is(Stream::Stdout));
 
     Dispatch::new()
         .chain(

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -99,7 +99,7 @@ fn missing_bcrypt_salt() -> Result<(), Box<dyn Error>> {
 fn bcrypt_invalid_salt_hex_odd_digits() -> Result<(), Box<dyn Error>> {
     let cmd = setup(vec!["Hello, world!", "bcrypt", "-c", "1", "-s", "1a54e"])?;
 
-    assert_errors(cmd, vec!["hex must be of even digits"]);
+    assert_errors(cmd, vec!["hex must have even length"]);
 
     Ok(())
 }
@@ -117,7 +117,7 @@ fn bcrypt_invalid_salt_incorrect_length_short() -> Result<(), Box<dyn Error>> {
 
     assert_errors(
         cmd,
-        vec!["incorrect salt length (should be 16 bytes, found 6)"],
+        vec!["incorrect salt length (expected 16 bytes, found 6)"],
     );
 
     Ok(())
@@ -136,7 +136,7 @@ fn bcrypt_invalid_salt_incorrect_length_long() -> Result<(), Box<dyn Error>> {
 
     assert_errors(
         cmd,
-        vec!["incorrect salt length (should be 16 bytes, found 22)"],
+        vec!["incorrect salt length (expected 16 bytes, found 22)"],
     );
 
     Ok(())


### PR DESCRIPTION
Create `SaltFromStrError` enum containing all possible error variants related to parsing a salt from an inputted string