### PR TITLE
Rename `HshErr` to `HshError` and restructure variant

### DIFF
--- a/src/bcrypt.rs
+++ b/src/bcrypt.rs
@@ -7,7 +7,7 @@ use lazy_static::lazy_static;
 use regex::Regex;
 
 // Internal imports
-use crate::error::{HshErr, HshResult, SaltFromStrError};
+use crate::error::{HshError, HshResult, SaltFromStrError};
 use crate::format::get_salt_format;
 use crate::hasher::Hasher;
 use crate::types::{Format, HashOutput};
@@ -101,11 +101,11 @@ impl Salt {
 }
 
 impl FromStr for Salt {
-    type Err = HshErr;
+    type Err = HshError;
 
     fn from_str(str: &str) -> HshResult<Salt> {
         if str.is_empty() {
-            return Err(HshErr::SaltFromStrError(SaltFromStrError::BlankStr));
+            return Err(HshError::SaltFromStrError(SaltFromStrError::BlankStr));
         }
 
         match get_salt_format() {
@@ -135,7 +135,7 @@ impl Hasher for BcryptHasher {
 
     fn hash(&self, input: BcryptInput, bytes: &[u8]) -> HshResult<HashOutput> {
         if bytes.is_empty() || bytes.len() > 72 {
-            return Err(HshErr::UnsuportedStrLength(String::from(
+            return Err(HshError::UnsuportedStrLength(String::from(
                 "input string for bcrypt hash function must be between 0 and 72 bytes",
             )));
         }
@@ -359,7 +359,7 @@ mod test {
 
             let err = Salt::from_str(&bytes).unwrap_err();
 
-            assert_eq!(HshErr::SaltFromStrError(SaltFromStrError::BlankStr), err);
+            assert_eq!(HshError::SaltFromStrError(SaltFromStrError::BlankStr), err);
         });
     }
 
@@ -371,7 +371,7 @@ mod test {
             let err = Salt::from_str(&bytes).unwrap_err();
 
             assert_eq!(
-                HshErr::SaltFromStrError(SaltFromStrError::InvalidByte(
+                HshError::SaltFromStrError(SaltFromStrError::InvalidByte(
                     String::from("nineteen"),
                     7
                 )),
@@ -389,7 +389,7 @@ mod test {
             let err = Salt::from_str(&bytes).unwrap_err();
 
             assert_eq!(
-                HshErr::SaltFromStrError(SaltFromStrError::IncorrectLength(16, 22)),
+                HshError::SaltFromStrError(SaltFromStrError::IncorrectLength(16, 22)),
                 err,
             );
         })
@@ -414,7 +414,7 @@ mod test {
 
             let err = Salt::from_str(&hex).unwrap_err();
 
-            assert_eq!(HshErr::SaltFromStrError(SaltFromStrError::BlankStr), err);
+            assert_eq!(HshError::SaltFromStrError(SaltFromStrError::BlankStr), err);
         });
     }
 
@@ -426,7 +426,7 @@ mod test {
             let err = Salt::from_str(&hex).unwrap_err();
 
             assert_eq!(
-                HshErr::SaltFromStrError(SaltFromStrError::InvalidHexLength),
+                HshError::SaltFromStrError(SaltFromStrError::InvalidHexLength),
                 err
             );
         });
@@ -440,7 +440,7 @@ mod test {
             let err = Salt::from_str(&hex).unwrap_err();
 
             assert_eq!(
-                HshErr::SaltFromStrError(SaltFromStrError::InvalidHexCharacter('n', 1)),
+                HshError::SaltFromStrError(SaltFromStrError::InvalidHexCharacter('n', 1)),
                 err
             );
         });
@@ -457,7 +457,7 @@ mod test {
             let err = Salt::from_str(&hex).unwrap_err();
 
             assert_eq!(
-                HshErr::SaltFromStrError(SaltFromStrError::IncorrectLength(16, 22)),
+                HshError::SaltFromStrError(SaltFromStrError::IncorrectLength(16, 22)),
                 err,
             );
         });
@@ -487,7 +487,7 @@ mod test {
 
             let err = Salt::from_str(&base64).unwrap_err();
 
-            assert_eq!(HshErr::SaltFromStrError(SaltFromStrError::BlankStr), err);
+            assert_eq!(HshError::SaltFromStrError(SaltFromStrError::BlankStr), err);
         });
     }
 
@@ -499,7 +499,7 @@ mod test {
             let err = Salt::from_str(&base64).unwrap_err();
 
             assert_eq!(
-                HshErr::SaltFromStrError(SaltFromStrError::InvalidBase64Length),
+                HshError::SaltFromStrError(SaltFromStrError::InvalidBase64Length),
                 err
             );
         });
@@ -514,8 +514,8 @@ mod test {
             let err = Salt::from_str(&base64).unwrap_err();
 
             assert_eq!(
-                HshErr::SaltFromStrError(SaltFromStrError::InvalidBase64Character(';', 8)),
-                err
+                HshError::SaltFromStrError(SaltFromStrError::InvalidBase64Character(';', 8)),
+                err,
             );
         });
     }
@@ -536,7 +536,7 @@ mod test {
             let err = Salt::from_str(&base64).unwrap_err();
 
             assert_eq!(
-                HshErr::SaltFromStrError(SaltFromStrError::IncorrectLength(16, 22)),
+                HshError::SaltFromStrError(SaltFromStrError::IncorrectLength(16, 22)),
                 err,
             );
         });
@@ -578,10 +578,10 @@ mod test {
         let err = BcryptHasher.hash_str(input, "").unwrap_err();
 
         assert_eq!(
-            HshErr::UnsuportedStrLength(String::from(
+            HshError::UnsuportedStrLength(String::from(
                 "input string for bcrypt hash function must be between 0 and 72 bytes"
             )),
-            err
+            err,
         );
     }
 
@@ -610,7 +610,7 @@ mod test {
         let err = BcryptHasher.hash(input, &[]).unwrap_err();
 
         assert_eq!(
-            HshErr::UnsuportedStrLength(String::from(
+            HshError::UnsuportedStrLength(String::from(
                 "input string for bcrypt hash function must be between 0 and 72 bytes"
             )),
             err
@@ -628,10 +628,10 @@ mod test {
         let err = BcryptHasher.hash(input, &bytes).unwrap_err();
 
         assert_eq!(
-            HshErr::UnsuportedStrLength(String::from(
+            HshError::UnsuportedStrLength(String::from(
                 "input string for bcrypt hash function must be between 0 and 72 bytes"
             )),
-            err
+            err,
         );
     }
 

--- a/src/bcrypt.rs
+++ b/src/bcrypt.rs
@@ -135,9 +135,7 @@ impl Hasher for BcryptHasher {
 
     fn hash(&self, input: BcryptInput, bytes: &[u8]) -> HshResult<HashOutput> {
         if bytes.is_empty() || bytes.len() > 72 {
-            return Err(HshError::UnsuportedStrLength(String::from(
-                "input string for bcrypt hash function must be between 0 and 72 bytes",
-            )));
+            return Err(HshError::UnsuportedBcryptLength);
         }
 
         let mut hash: [u8; 24] = [0; 24];
@@ -577,12 +575,7 @@ mod test {
 
         let err = BcryptHasher.hash_str(input, "").unwrap_err();
 
-        assert_eq!(
-            HshError::UnsuportedStrLength(String::from(
-                "input string for bcrypt hash function must be between 0 and 72 bytes"
-            )),
-            err,
-        );
+        assert_eq!(HshError::UnsuportedBcryptLength, err);
     }
 
     #[test]
@@ -609,12 +602,7 @@ mod test {
 
         let err = BcryptHasher.hash(input, &[]).unwrap_err();
 
-        assert_eq!(
-            HshError::UnsuportedStrLength(String::from(
-                "input string for bcrypt hash function must be between 0 and 72 bytes"
-            )),
-            err
-        );
+        assert_eq!(HshError::UnsuportedBcryptLength, err);
     }
 
     #[test]
@@ -627,12 +615,7 @@ mod test {
 
         let err = BcryptHasher.hash(input, &bytes).unwrap_err();
 
-        assert_eq!(
-            HshError::UnsuportedStrLength(String::from(
-                "input string for bcrypt hash function must be between 0 and 72 bytes"
-            )),
-            err,
-        );
+        assert_eq!(HshError::UnsuportedBcryptLength, err);
     }
 
     proptest! {

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,14 +10,14 @@ use log::error;
 #[derive(Debug, PartialEq)]
 pub enum HshError {
     SaltFromStrError(SaltFromStrError),
-    UnsuportedStrLength(String),
+    UnsuportedBcryptLength,
 }
 
 impl HshError {
     pub fn exitcode(&self) -> ExitCode {
         match self {
             Self::SaltFromStrError(_) => DATAERR,
-            Self::UnsuportedStrLength(_) => DATAERR,
+            Self::UnsuportedBcryptLength => DATAERR,
         }
     }
 }
@@ -25,9 +25,11 @@ impl HshError {
 impl Display for HshError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Self::SaltFromStrError(msg) => f.write_fmt(format_args!("error parsing salt: {}", msg)),
-            Self::UnsuportedStrLength(msg) => {
-                f.write_fmt(format_args!("unsuported string length: {}", msg))
+            Self::SaltFromStrError(msg) => {
+                f.write_fmt(format_args!("error parsing salt: {}", msg))
+            }
+            Self::UnsuportedBcryptLength => {
+                f.write_str("input string for bcrypt hash function must be between 0 and 72 bytes")
             }
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -57,12 +57,29 @@ impl Display for SaltFromStrError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::BlankStr => f.write_str("salt cannot be blank"),
-            Self::IncorrectLength(exp, act) => f.write_fmt(format_args!("incorrect salt length (expected {} bytes, found {})", exp, act)),
-            Self::InvalidBase64Character(c, i) => f.write_fmt(format_args!("invalid character '{}' in base64 string at index {}", c, i)),
-            Self::InvalidBase64Length => f.write_str("length of base64 string must be divisible by 4"),
-            Self::InvalidByte(b, i) => f.write_fmt(format_args!("byte input contains invalid byte '{}' at array index {}", b, i)),
-            Self::InvalidByteFormat => f.write_str("byte input was incorrectly formatted (string should begin and end with '[' and ']' and contain a comma-separated list of values)"),
-            Self::InvalidHexCharacter(c, i) => f.write_fmt(format_args!("invalid character '{}' in hex at index {}", c, i)),
+            Self::IncorrectLength(exp, act) => f.write_fmt(format_args!(
+                "incorrect salt length (expected {} bytes, found {})",
+                exp, act
+            )),
+            Self::InvalidBase64Character(c, i) => f.write_fmt(format_args!(
+                "invalid character '{}' in base64 string at index {}",
+                c, i
+            )),
+            Self::InvalidBase64Length => {
+                f.write_str("length of base64 string must be divisible by 4")
+            }
+            Self::InvalidByte(b, i) => f.write_fmt(format_args!(
+                "byte input contains invalid byte '{}' at array index {}",
+                b, i
+            )),
+            Self::InvalidByteFormat => f.write_str(
+                "byte input was incorrectly formatted (string should begin and end with '[' and \
+                    ']' and contain a comma-separated list of values)",
+            ),
+            Self::InvalidHexCharacter(c, i) => f.write_fmt(format_args!(
+                "invalid character '{}' in hex at index {}",
+                c, i
+            )),
             Self::InvalidHexLength => f.write_fmt(format_args!("hex must have even length")),
         }
     }
@@ -90,41 +107,40 @@ mod test {
     use super::*;
 
     #[test]
-    fn hsh_err_display_salt_from_str_error() {
-        let err = HshErr::SaltFromStrError(SaltFromStrError::BlankStr);
+    fn hsh_error_display_salt_from_str_error() {
+        let err = HshError::SaltFromStrError(SaltFromStrError::BlankStr);
         let msg = format!("{}", err);
         assert_eq!("error parsing salt: salt cannot be blank", &msg);
     }
 
     #[test]
-    fn hsh_err_display_unsuported_str_length() {
-        let err = HshErr::UnsuportedStrLength(String::from(
-            "input string for bcrypt hash function must be between 0 and 72 bytes",
-        ));
+    fn hsh_error_display_unsuported_bcrypt_length() {
+        let err = HshError::UnsuportedBcryptLength;
         let msg = format!("{}", err);
-        assert_eq!("unsuported string length: input string for bcrypt hash function must be between 0 and 72 bytes", &msg);
-    }
-
-    #[test]
-    fn hsh_err_exit_code_salt_from_str_error() {
-        let err = HshErr::SaltFromStrError(SaltFromStrError::BlankStr);
-        let code = err.exitcode();
-        assert_eq!(65i32, code);
-    }
-
-    #[test]
-    fn hsh_err_exit_code_unsuported_str_length() {
-        let err = HshErr::UnsuportedStrLength(String::from(
+        assert_eq!(
             "input string for bcrypt hash function must be between 0 and 72 bytes",
-        ));
+            &msg
+        );
+    }
+
+    #[test]
+    fn hsh_error_exit_code_salt_from_str_error() {
+        let err = HshError::SaltFromStrError(SaltFromStrError::BlankStr);
         let code = err.exitcode();
         assert_eq!(65i32, code);
     }
 
     #[test]
-    fn hsh_err_from_salt_from_str_error() {
-        let err = HshErr::from(SaltFromStrError::BlankStr);
-        assert_eq!(HshErr::SaltFromStrError(SaltFromStrError::BlankStr), err);
+    fn hsh_error_exit_code_unsuported_str_length() {
+        let err = HshError::UnsuportedBcryptLength;
+        let code = err.exitcode();
+        assert_eq!(65i32, code);
+    }
+
+    #[test]
+    fn hsh_error_from_salt_from_str_error() {
+        let err = HshError::from(SaltFromStrError::BlankStr);
+        assert_eq!(HshError::SaltFromStrError(SaltFromStrError::BlankStr), err);
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,12 +8,12 @@ use exitcode::{ExitCode, DATAERR};
 use log::error;
 
 #[derive(Debug, PartialEq)]
-pub enum HshErr {
+pub enum HshError {
     SaltFromStrError(SaltFromStrError),
     UnsuportedStrLength(String),
 }
 
-impl HshErr {
+impl HshError {
     pub fn exitcode(&self) -> ExitCode {
         match self {
             Self::SaltFromStrError(_) => DATAERR,
@@ -22,22 +22,20 @@ impl HshErr {
     }
 }
 
-impl Display for HshErr {
+impl Display for HshError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            HshErr::SaltFromStrError(msg) => {
-                f.write_fmt(format_args!("error parsing salt: {}", msg))
-            }
-            HshErr::UnsuportedStrLength(msg) => {
+            Self::SaltFromStrError(msg) => f.write_fmt(format_args!("error parsing salt: {}", msg)),
+            Self::UnsuportedStrLength(msg) => {
                 f.write_fmt(format_args!("unsuported string length: {}", msg))
             }
         }
     }
 }
 
-impl Error for HshErr {}
+impl Error for HshError {}
 
-impl From<SaltFromStrError> for HshErr {
+impl From<SaltFromStrError> for HshError {
     fn from(err: SaltFromStrError) -> Self {
         Self::SaltFromStrError(err)
     }
@@ -72,7 +70,7 @@ impl Display for SaltFromStrError {
 
 impl Error for SaltFromStrError {}
 
-pub type HshResult<T> = Result<T, HshErr>;
+pub type HshResult<T> = Result<T, HshError>;
 
 impl<T> UnwrapOrExit<T> for HshResult<T> {
     fn unwrap_or_exit(self) -> T {

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,9 +25,7 @@ impl HshError {
 impl Display for HshError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Self::SaltFromStrError(msg) => {
-                f.write_fmt(format_args!("error parsing salt: {}", msg))
-            }
+            Self::SaltFromStrError(msg) => f.write_fmt(format_args!("error parsing salt: {}", msg)),
             Self::UnsuportedBcryptLength => {
                 f.write_str("input string for bcrypt hash function must be between 0 and 72 bytes")
             }

--- a/src/types.rs
+++ b/src/types.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 use b64::{CharacterSet, Config, Newline, ToBase64};
 
 // Internal imports
-use crate::error::{HshErr, HshResult};
+use crate::error::{HshError, HshResult};
 use crate::format::get_format;
 
 // Re-exports
@@ -94,7 +94,7 @@ impl HashFunction {
 }
 
 impl FromStr for HashFunction {
-    type Err = HshErr;
+    type Err = HshError;
 
     fn from_str(str: &str) -> HshResult<HashFunction> {
         use super::HashFunction::*;
@@ -200,7 +200,7 @@ impl Format {
 }
 
 impl FromStr for Format {
-    type Err = HshErr;
+    type Err = HshError;
 
     fn from_str(str: &str) -> HshResult<Format> {
         match str {


### PR DESCRIPTION
- Rename `HshErr` to `HshError`
- Rename `UnsuportedStrLength` variant to `UnsuportedBcryptLength` and simplify error messages and handling