### PR TITLE
:shirt: Fix clippy warning in `cli.rs`

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -77,7 +77,7 @@ impl Cli {
     }
 
     fn salt_format(&self) -> Format {
-        self.salt_format.unwrap_or(self.format())
+        self.salt_format.unwrap_or_else(|| self.format())
     }
 
     fn verbosity(&self) -> LevelFilter {


### PR DESCRIPTION
Fix clippy warning by replacing `.unwrap_or()` call with `.unwrap_or_else()` when the default value is the resault of a method call, since `unwrap_or` is evaluated eagerly and `unwrap_or_else` is evaluated lazily.