### PR TITLE
:green_heart: Remove Windows target from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,6 @@ jobs:
   - env: TARGET=x86_64-apple-darwin
     os: osx
 
-  # Windows
-  - env: TARGET=x86_64-pc-windows-gnu
-
   # Nightly
   - env: TARGET=x86_64-unknown-linux-gnu
     rust: nightly


### PR DESCRIPTION
Remove Windows target from Travis CI as it is unnecessary and overlaps with AppVeyor targets